### PR TITLE
fix: sticky elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [ ] Update app icons.
 - [ ] Add OpenGraph meta information to all pages.
 - [ ] Separate 404 for home (site) and app. They need different redirects and copy
+- [ ] Update sticky bottom calc accounting for navbar; currently: `bottom-[calc(64px+env(safe-area-inset-bottom))]`
 
 ## Major updates
 

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list-client.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list-client.tsx
@@ -182,7 +182,7 @@ export default function ShoppingListClient() {
 
             {/* Generate Button */}
             {selectedRecipeIds.size > 0 && (
-              <div className="sticky bottom-20 mt-8 pb-4">
+              <div className="sticky bottom-[calc(64px+env(safe-area-inset-bottom))] mt-8 pb-4">
                 <Button
                   size="lg"
                   className="w-full shadow-lg"

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -382,7 +382,7 @@ export default function ShoppingList({
             {/* Action Buttons */}
             {isFinalised ? (
               // Final state: Print, Share, Done
-              <div className="flex gap-2 flex-wrap sticky bottom-20">
+              <div className="flex gap-2 flex-wrap sticky bottom-[calc(64px+env(safe-area-inset-bottom))]">
                 <Button
                   variant="outline"
                   className="flex-1"
@@ -409,7 +409,7 @@ export default function ShoppingList({
               </div>
             ) : (
               // Editing state: Confirm/Save
-              <div className="flex gap-2 sticky bottom-20">
+              <div className="flex gap-2 sticky bottom-[calc(64px+env(safe-area-inset-bottom))]">
                 <Button variant="outline" className="flex-1" onClick={onBack}>
                   Cancel
                 </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted sticky action buttons in the Shopping List to respect device safe-area insets, improving visibility and tap targets on devices with bottom home indicators.
  - Updated positioning for the Generate button and action containers (Print/Share/Done and Cancel/Confirm) to avoid overlap with system UI.

- Documentation
  - Added a minor update note describing the safe-area-aware sticky bottom offset for action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->