### PR TITLE
Add showcase recipes to homepage

### DIFF
--- a/convex/recipes.ts
+++ b/convex/recipes.ts
@@ -328,6 +328,63 @@ export const getSystemRecipes = query({
 });
 
 /**
+ * Public marketing: a small set of system recipes for the homepage “example week”.
+ * Prefers recipes with hero images; deterministic order (title sort within each group).
+ */
+export const getHomepageShowcaseRecipes = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const cap = Math.min(Math.max(1, args.limit ?? 7), 14);
+
+    const recipes = await ctx.db
+      .query("recipes")
+      .withIndex("by_source", (q) => q.eq("source", "system"))
+      .collect();
+
+    type Row = {
+      _id: Id<"recipes">;
+      title: string;
+      publicSlug: string | null;
+      image: string | null;
+      prepTime: number;
+      cookTime?: number | null;
+      totalTimeMinutes?: number;
+      category: Doc<"recipes">["category"];
+      primaryProtein: Doc<"recipes">["primaryProtein"];
+      nutrition: Doc<"recipes">["nutrition"];
+    };
+
+    const rows: Row[] = await Promise.all(
+      recipes.map(async (r) => ({
+        _id: r._id,
+        title: r.title,
+        publicSlug:
+          typeof r.publicSlug === "string" && r.publicSlug.length > 0
+            ? r.publicSlug
+            : null,
+        image: r.image ? await ctx.storage.getUrl(r.image) : null,
+        prepTime: r.prepTime ?? 0,
+        cookTime: r.cookTime ?? undefined,
+        totalTimeMinutes: r.totalTimeMinutes,
+        category: r.category,
+        primaryProtein: r.primaryProtein,
+        nutrition: r.nutrition,
+      })),
+    );
+
+    const sortByTitle = (a: Row, b: Row) =>
+      a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+
+    const withImage = rows.filter((r) => r.image != null).sort(sortByTitle);
+    const withoutImage = rows.filter((r) => r.image == null).sort(sortByTitle);
+
+    return [...withImage, ...withoutImage].slice(0, cap);
+  },
+});
+
+/**
  * Public discover URLs for sitemap.xml only: `publicSlug` + `updatedAt`.
  * Does not call storage (no image URLs) and returns a small payload vs `getSystemRecipes`.
  */

--- a/src/app/(site)/_components/example-week-section.tsx
+++ b/src/app/(site)/_components/example-week-section.tsx
@@ -1,6 +1,20 @@
 "use client";
 
-const EXAMPLE_DAYS = [
+import { ROUTES } from "@/app/constants";
+import { Card, CardContent } from "@/components/ui/card";
+import type { HomepageShowcaseRecipe } from "@/lib/homepage-showcase-recipes";
+import { cn } from "@/lib/utils";
+import {
+  ArrowRight,
+  CalendarCheck,
+  ChevronLeft,
+  ChevronRight,
+  Sparkles,
+} from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+const FALLBACK_DAYS = [
   "Roast chicken & greens",
   "Pasta puttanesca",
   "Lentil dhal",
@@ -10,40 +24,284 @@ const EXAMPLE_DAYS = [
   "Sheet-pan sausages",
 ];
 
-export function ExampleWeekSection() {
-  return (
-    <section
-      className="py-16 bg-background"
-      aria-labelledby="example-week-heading"
-    >
-      <div className="container mx-auto px-4 max-w-4xl">
-        <div className="text-center mb-10">
-          <h2
-            id="example-week-heading"
-            className="text-3xl font-bold mb-4"
-          >
-            One plan. Your week.
-          </h2>
-          <p className="text-lg text-muted-foreground max-w-xl mx-auto">
-            Generated from your recipes. Yours to tweak.
-          </p>
+function recipeMetaLabel(recipe: HomepageShowcaseRecipe) {
+  const totalMin =
+    recipe.totalTimeMinutes ?? recipe.prepTime + (recipe.cookTime ?? 0);
+  const timeLabel = totalMin > 0 ? `${totalMin} min` : "";
+  const caloriesLabel =
+    recipe.nutrition?.calories != null
+      ? `${recipe.nutrition.calories} kcal`
+      : "";
+  return [timeLabel, caloriesLabel].filter(Boolean).join(" · ");
+}
+
+function ExampleDayCard({
+  dayIndex,
+  recipe,
+  imagePriority,
+}: {
+  dayIndex: number;
+  recipe: HomepageShowcaseRecipe;
+  /** First tiles: eager load for faster visible food photography. */
+  imagePriority?: boolean;
+}) {
+  const meta = recipeMetaLabel(recipe);
+  const href =
+    recipe.publicSlug != null ? ROUTES.discoverRecipe(recipe.publicSlug) : null;
+
+  const cardClass = cn(
+    "group flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-md ring-1 ring-black/5",
+    /* Explicit translate-y-0 so hover lift animates instead of jumping. */
+    "translate-y-0 transition-[translate,box-shadow,border-color] duration-300 ease-out",
+    href &&
+      "hover:-translate-y-0.5 hover:border-primary/35 hover:shadow-lg hover:ring-primary/10",
+  );
+
+  const body = (
+    <>
+      {/* Tall frame so food photography reads clearly (not postage-stamp tiles). */}
+      <div className="relative aspect-3/4 min-h-[168px] w-full overflow-hidden bg-muted sm:min-h-[192px] lg:min-h-[200px]">
+        {recipe.image ? (
+          <Image
+            src={recipe.image}
+            alt={recipe.title}
+            fill
+            unoptimized
+            priority={imagePriority}
+            className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.06]"
+            sizes="(max-width: 768px) 72vw, (max-width: 1024px) 28vw, (max-width: 1536px) 22vw, 180px"
+          />
+        ) : (
+          <div className="flex size-full items-center justify-center bg-linear-to-br from-muted to-muted/60 px-3 text-center text-sm text-muted-foreground">
+            {recipe.title}
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute left-2 top-2 rounded-md bg-black/60 px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-white shadow-sm backdrop-blur-[2px]">
+          Day {dayIndex + 1}
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3">
-          {EXAMPLE_DAYS.map((label, i) => (
-            <div
-              key={String(label)}
-              className="p-4 rounded-lg border border-border bg-card text-center"
-            >
-              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Day {i + 1}
-              </span>
-              <p className="mt-2 text-sm font-medium text-foreground line-clamp-2">
-                {label}
-              </p>
-            </div>
-          ))}
+        {recipe.image ? (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-t from-black/85 via-black/45 to-transparent px-3 pb-3 pt-14 sm:pt-16">
+            <p className="line-clamp-2 text-sm font-semibold leading-snug text-white drop-shadow-md sm:text-base">
+              {recipe.title}
+            </p>
+            {meta ? (
+              <p className="mt-1 text-xs font-medium text-white/90">{meta}</p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={cn(
+          cardClass,
+          "block h-full min-w-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        )}
+        aria-label={`${recipe.title}, day ${dayIndex + 1}`}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <article className={cardClass}>{body}</article>;
+}
+
+function ExampleWeekCtaCard() {
+  const cardClass = cn(
+    "group relative flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-primary/15 bg-card shadow-md ring-1 ring-primary/5",
+    "translate-y-0 transition-[transform,box-shadow,border-color] duration-300 ease-out motion-reduce:transition-none motion-reduce:hover:translate-y-0",
+    "hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg hover:ring-primary/15",
+    "outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  );
+
+  return (
+    <Link
+      href={ROUTES.SIGN_UP}
+      className={cn(cardClass, "block min-w-0")}
+      aria-label="Sign up to generate your weekly meal plan in one click"
+    >
+      <div className="relative flex aspect-3/4 min-h-[168px] w-full flex-col justify-between overflow-hidden sm:min-h-[192px] lg:min-h-[200px]">
+        {/* Very subtle tint so copy stays the focus */}
+        <div className="absolute inset-0 bg-card" aria-hidden />
+        <div
+          className="absolute inset-0 bg-linear-to-br from-primary/8 via-transparent to-accent/10 dark:from-primary/12 dark:to-accent/12"
+          aria-hidden
+        />
+        <div
+          className="absolute -right-14 -top-14 size-44 rounded-full bg-primary/10 blur-3xl dark:bg-primary/15"
+          aria-hidden
+        />
+        <div
+          className="absolute -bottom-16 -left-10 size-48 rounded-full bg-accent/10 blur-3xl dark:bg-violet-500/12"
+          aria-hidden
+        />
+
+        <div className="relative flex flex-1 flex-col p-4 sm:p-5">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-background/90 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-primary shadow-sm ring-1 ring-primary/10 backdrop-blur-sm dark:bg-background/60">
+              <Sparkles className="size-3.5 shrink-0 text-primary" />
+              Free in beta
+            </span>
+          </div>
+
+          <div className="mt-auto space-y-2">
+            <h3 className="text-balance text-lg font-bold leading-tight tracking-tight text-foreground sm:text-xl">
+              Your week, decided in one click
+            </h3>
+            <p className="text-pretty text-sm leading-snug text-muted-foreground sm:text-[0.9375rem]">
+              Generate a balanced weekly meal plan and a shopping list you can
+              actually shop from.
+            </p>
+            <span className="inline-flex items-center gap-1.5 pt-1 text-sm font-semibold text-primary">
+              Get started
+              <ArrowRight className="size-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5" />
+            </span>
+          </div>
         </div>
+      </div>
+    </Link>
+  );
+}
+
+function StaticFallbackWeek() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 md:gap-4 2xl:grid-cols-7 2xl:gap-4">
+      {FALLBACK_DAYS.map((label, i) => (
+        <div
+          key={String(label)}
+          className="rounded-xl border border-border bg-card p-4 text-center shadow-sm"
+        >
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Day {i + 1}
+          </span>
+          <p className="mt-2 line-clamp-2 text-sm font-medium text-foreground">
+            {label}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ExampleWeekSection({
+  recipes = [],
+}: {
+  recipes?: HomepageShowcaseRecipe[];
+}) {
+  const hasReal = recipes.length > 0;
+
+  return (
+    <section
+      className="py-16 sm:py-20 bg-muted/25"
+      aria-labelledby="example-week-heading"
+    >
+      <div className="container mx-auto max-w-7xl px-4">
+        <Card className="overflow-hidden border-primary/20 bg-primary/4 shadow-sm">
+          <CardContent className="p-5 sm:p-8">
+            <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 flex-1 items-start gap-3">
+                <div className="shrink-0 rounded-lg bg-primary/15 p-2.5">
+                  <CalendarCheck className="size-7 text-primary" />
+                </div>
+                <div className="min-w-0">
+                  <h2
+                    id="example-week-heading"
+                    className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+                  >
+                    One plan. Your week.
+                  </h2>
+                  <p className="mt-1.5 max-w-2xl text-muted-foreground sm:text-lg">
+                    Curated picks and the recipes you add, all yours to tweak.
+                    {hasReal ? (
+                      <> Here are a few real recipes from our collection.</>
+                    ) : null}
+                  </p>
+                </div>
+              </div>
+              {hasReal ? (
+                <Link
+                  href={ROUTES.DISCOVER}
+                  className="shrink-0 text-sm font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  Browse all curated recipes
+                </Link>
+              ) : null}
+            </div>
+
+            {hasReal ? (
+              <>
+                {/* Narrow screens: horizontal strip with clear scroll / swipe affordance. */}
+                <div className="md:hidden -mx-1 px-1">
+                  <p className="mb-2 flex items-center justify-center gap-2 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    <ChevronLeft
+                      className="size-3.5 shrink-0 opacity-50"
+                      aria-hidden
+                    />
+                    Swipe or scroll sideways
+                    <ChevronRight
+                      className="size-3.5 shrink-0 opacity-50"
+                      aria-hidden
+                    />
+                  </p>
+                  <p className="mb-3 text-center text-[11px] text-muted-foreground/90">
+                    A peek of the next card shows there&apos;s more to explore.
+                  </p>
+                  <div
+                    className={cn(
+                      "flex snap-x snap-mandatory gap-3 overflow-x-auto overscroll-x-contain px-1 pb-2",
+                      "scroll-pl-3 scroll-pr-2 touch-pan-x",
+                      "[scrollbar-width:thin]",
+                      "[scrollbar-color:var(--color-muted-foreground)_transparent]",
+                      "[&::-webkit-scrollbar]:h-2",
+                      "[&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-muted/40",
+                      "[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/35 [&::-webkit-scrollbar-thumb]:hover:bg-muted-foreground/50",
+                    )}
+                  >
+                    {recipes.slice(0, 7).map((recipe, i) => (
+                      <div
+                        key={recipe._id}
+                        className="w-[min(70vw,17rem)] shrink-0 snap-center sm:w-[min(68vw,17rem)]"
+                      >
+                        <ExampleDayCard
+                          dayIndex={i}
+                          recipe={recipe}
+                          imagePriority={i < 3}
+                        />
+                      </div>
+                    ))}
+                    <div className="w-[min(70vw,17rem)] shrink-0 snap-center sm:w-[min(68vw,17rem)]">
+                      <ExampleWeekCtaCard />
+                    </div>
+                  </div>
+                </div>
+                {/* md+: 8 tiles — tighter columns on 2xl so eight fit without crowding earlier breakpoints. */}
+                <div className="hidden md:grid md:grid-cols-3 md:gap-4 lg:grid-cols-4 lg:gap-5 2xl:grid-cols-8 2xl:gap-4">
+                  {recipes.slice(0, 7).map((recipe, i) => (
+                    <div key={recipe._id} className="min-w-0">
+                      <ExampleDayCard
+                        dayIndex={i}
+                        recipe={recipe}
+                        imagePriority={i < 4}
+                      />
+                    </div>
+                  ))}
+                  <div className="min-w-0">
+                    <ExampleWeekCtaCard />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <StaticFallbackWeek />
+            )}
+          </CardContent>
+        </Card>
       </div>
     </section>
   );

--- a/src/app/(site)/_components/home-content.tsx
+++ b/src/app/(site)/_components/home-content.tsx
@@ -2,6 +2,7 @@
 
 import { BalanceVarietySection } from "@/app/(site)/_components/balance-variety-section";
 import { ExampleWeekSection } from "@/app/(site)/_components/example-week-section";
+import type { HomepageShowcaseRecipe } from "@/lib/homepage-showcase-recipes";
 import { HowItPlansSection } from "@/app/(site)/_components/how-it-plans-section";
 import { APP_NAME, ROUTES } from "@/app/constants";
 import { PublicPageTracker } from "@/components/analytics/public-page-tracker";
@@ -29,14 +30,20 @@ const HERO_IMAGE = "/hero-2.png";
 const CTA_BUTTON_CLASSES =
   "text-lg px-8 py-4 h-auto shadow-lg hover:shadow-xl transition-all duration-300 w-full sm:w-auto";
 
-export default function HomeContent() {
+type HomeContentProps = {
+  showcaseRecipes?: HomepageShowcaseRecipe[];
+};
+
+export default function HomeContent({
+  showcaseRecipes = [],
+}: HomeContentProps) {
   return (
     <div className="flex flex-col">
       <PublicPageTracker
         event={ANALYTICS_EVENTS.LANDING_VIEWED}
         props={{ intent_topic: "home" }}
       />
-      {/* Hero Section — split layout: copy on solid background, image as featured visual */}
+      {/* Hero: split layout, copy left and image right */}
       <section className="relative min-h-[85vh] flex flex-col lg:flex-row lg:min-h-[90vh]">
         {/* Left: copy on readable background */}
         <div className="flex-1 flex items-center justify-center bg-background px-4 py-16 lg:py-24 lg:pl-[max(1rem,calc((100vw-1200px)/2))] lg:pr-8">
@@ -54,16 +61,24 @@ export default function HomeContent() {
             <div className="space-y-6">
               <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl font-bold tracking-tight leading-[1.1]">
                 <span className="text-foreground">
-                  Your personalised week of meals,
+                  Stop wondering what to cook every day.
                 </span>
                 <br />
-                <span className="text-primary">in one click.</span>
+                <span className="text-primary">
+                  Your week of meals, decided in one click.
+                </span>
               </h1>
 
+              <p className="text-lg sm:text-xl text-foreground/90 max-w-xl mx-auto lg:mx-0 leading-relaxed font-medium">
+                Build a balanced weekly meal plan in one click, then turn it
+                into a shopping list you can shop from and share with your
+                household.
+              </p>
+
               <p className="text-lg sm:text-xl text-muted-foreground max-w-xl mx-auto lg:mx-0 leading-relaxed">
-                Sign up in seconds, then one click for a balanced week of
-                dinners. Free while we&apos;re in beta. Your feedback shapes
-                what we build.{" "}
+                Start with curated meals, and add your own recipes whenever you
+                like. Free while we&apos;re in beta. Your feedback shapes what we
+                build.{" "}
                 <Link
                   href={ROUTES.BETA}
                   className="text-primary hover:text-primary/80 underline underline-offset-2"
@@ -83,70 +98,89 @@ export default function HomeContent() {
               </div>
             </div>
 
-            <div className="flex flex-col gap-3 justify-center lg:justify-start items-stretch sm:items-center sm:flex-row sm:flex-wrap">
-              <Authenticated>
-                <Button asChild size="lg" className={CTA_BUTTON_CLASSES}>
-                  <Link href={ROUTES.DASHBOARD}>
-                    Go to dashboard
-                    <ArrowRight className="ml-2 size-5" />
-                  </Link>
-                </Button>
-              </Authenticated>
-              <Unauthenticated>
-                <SignUpButton mode="modal">
-                  <Button
-                    size="lg"
-                    className={CTA_BUTTON_CLASSES}
-                    onClick={() => {
-                      trackEvent(ANALYTICS_EVENTS.CTA_CLICKED, {
-                        cta_type: "home_hero_join_beta",
-                        intent_topic: "home",
-                      });
-                      trackEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
-                        source_surface: "home_hero",
-                      });
-                    }}
-                  >
-                    Join the beta (free)
-                    <ArrowRight className="ml-2 size-5" />
+            <div className="flex flex-col gap-3 justify-center lg:justify-start items-stretch sm:max-w-xl lg:max-w-none">
+              <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center sm:flex-wrap justify-center lg:justify-start">
+                <Authenticated>
+                  <Button asChild size="lg" className={CTA_BUTTON_CLASSES}>
+                    <Link href={ROUTES.DASHBOARD}>
+                      Go to dashboard
+                      <ArrowRight className="ml-2 size-5" />
+                    </Link>
                   </Button>
-                </SignUpButton>
-              </Unauthenticated>
-              <a
-                href="#how-it-plans"
-                className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 sm:py-3 order-last sm:order-0 text-center sm:text-left"
-                onClick={() => {
-                  trackEvent(ANALYTICS_EVENTS.SECONDARY_ACTION_TAKEN, {
-                    action_name: "scroll_how_it_works",
-                    source_surface: "home_hero",
-                  });
-                }}
-              >
-                See how it works
-              </a>
-            </div>
-
-            <div className="flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-3 sm:gap-6 text-sm text-muted-foreground pt-2">
-              <div className="flex items-center gap-2">
-                <CheckCircle className="size-4 text-primary shrink-0" />
-                <span>No credit card required</span>
+                </Authenticated>
+                <Unauthenticated>
+                  <SignUpButton mode="modal">
+                    <Button
+                      size="lg"
+                      className={CTA_BUTTON_CLASSES}
+                      onClick={() => {
+                        trackEvent(ANALYTICS_EVENTS.CTA_CLICKED, {
+                          cta_type: "home_hero_join_beta",
+                          intent_topic: "home",
+                        });
+                        trackEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
+                          source_surface: "home_hero",
+                        });
+                      }}
+                    >
+                      Join free beta
+                      <ArrowRight className="ml-2 size-5" />
+                    </Button>
+                  </SignUpButton>
+                </Unauthenticated>
+                <a
+                  href="#how-it-plans"
+                  className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 sm:py-3 text-center sm:text-left sm:order-0 order-last"
+                  onClick={() => {
+                    trackEvent(ANALYTICS_EVENTS.SECONDARY_ACTION_TAKEN, {
+                      action_name: "scroll_how_it_works",
+                      source_surface: "home_hero",
+                    });
+                  }}
+                >
+                  See how it works
+                </a>
               </div>
-              <div className="hidden sm:block size-1 bg-muted-foreground/30 rounded-full" />
-              <div className="flex items-center gap-2 text-center sm:text-left">
-                <CheckCircle className="size-4 text-primary shrink-0" />
-                <span>Open to everyone. Tell us what to improve.</span>
+
+              <Unauthenticated>
+                <p className="text-sm text-muted-foreground text-center lg:text-left">
+                  Then generate your week in one click.
+                </p>
+              </Unauthenticated>
+
+              <div className="flex flex-col gap-2 text-sm text-muted-foreground pt-1">
+                <div className="flex items-center gap-2 justify-center lg:justify-start">
+                  <CheckCircle className="size-4 text-primary shrink-0" />
+                  <span>Free while in beta</span>
+                </div>
+                <div className="flex items-center gap-2 justify-center lg:justify-start">
+                  <CheckCircle className="size-4 text-primary shrink-0" />
+                  <span>No credit card required</span>
+                </div>
+                <Unauthenticated>
+                  <div className="flex items-center gap-2 justify-center lg:justify-start">
+                    <CheckCircle className="size-4 text-primary shrink-0" />
+                    <span>Takes seconds to get started</span>
+                  </div>
+                </Unauthenticated>
+                <Authenticated>
+                  <div className="flex items-center gap-2 justify-center lg:justify-start">
+                    <CheckCircle className="size-4 text-primary shrink-0" />
+                    <span>Open to everyone. Tell us what to improve.</span>
+                  </div>
+                </Authenticated>
               </div>
             </div>
           </div>
         </div>
 
-        {/* Right: Hero 2 image as featured visual — no text overlay */}
+        {/* Right: hero image, no text overlay */}
         <div className="flex-1 relative flex items-center justify-center bg-muted/40 min-h-[50vh] lg:min-h-0 lg:pr-[max(1rem,calc((100vw-1200px)/2))] lg:pl-4">
           <div className="relative w-full max-w-2xl aspect-4/3 lg:aspect-6/5 mx-4 lg:mx-0">
             <div className="absolute inset-0 rounded-2xl lg:rounded-3xl overflow-hidden shadow-xl ring-1 ring-black/5 lg:shadow-2xl lg:-rotate-1">
               <Image
                 src={HERO_IMAGE}
-                alt="Kitchen counter with fresh herbs, lemons, and a meal-planning app on a tablet"
+                alt="Kitchen counter with fresh produce and a tablet showing a weekly meal plan and shopping list in Foodedo"
                 fill
                 className="object-cover"
                 priority
@@ -162,13 +196,14 @@ export default function HomeContent() {
         </div>
       </section>
 
+      <ExampleWeekSection recipes={showcaseRecipes} />
+
       <div className="container mt-4">
         <InstallPrompt />
       </div>
 
       <HowItPlansSection />
       <BalanceVarietySection />
-      <ExampleWeekSection />
 
       {/* What feeds your plan */}
       <section id="features" className="py-20 bg-muted/30 scroll-mt-20">
@@ -182,7 +217,7 @@ export default function HomeContent() {
             </p>
           </div>
 
-          {/* 1. Meal planning + shopping — lead, two columns */}
+          {/* 1. Meal planning + shopping (lead, two columns) */}
           <div className="grid lg:grid-cols-2 gap-6 md:gap-12 items-stretch mb-20">
             <div className="relative p-6 pt-14 rounded-lg border border-border bg-card overflow-visible">
               <div
@@ -197,9 +232,10 @@ export default function HomeContent() {
                   Your week, then your shop
                 </h3>
                 <p className="text-muted-foreground">
-                  Generate a full week in one click, or build it yourself. Add
-                  meals from your recipes, then generate a shopping list from
-                  the plan. Check off as you go.
+                  Generate a full week in one click, or build it yourself. Mix
+                  curated ideas with your own recipes and keep growing your
+                  library over time, then generate a shopping list from the plan
+                  and check items off as you go.
                 </p>
                 <Button asChild variant="outline" size="sm">
                   <Link href={ROUTES.MEAL_PLAN}>Meal planning</Link>
@@ -233,7 +269,7 @@ export default function HomeContent() {
             </div>
           </div>
 
-          {/* 2. Import from websites — image right */}
+          {/* 2. Import from websites, image right */}
           <div className="grid lg:grid-cols-2 gap-12 items-center mb-20">
             <div className="space-y-4">
               <h3 className="text-2xl font-bold">
@@ -258,7 +294,7 @@ export default function HomeContent() {
             </div>
           </div>
 
-          {/* 3. Recipe books + create your own — image left */}
+          {/* 3. Recipe books + create your own, image left */}
           <div className="grid lg:grid-cols-2 gap-12 items-center mb-20">
             <div className="order-2 lg:order-1 relative aspect-16/10 w-full rounded-lg overflow-hidden border border-border">
               <Image
@@ -282,7 +318,7 @@ export default function HomeContent() {
             </div>
           </div>
 
-          {/* 4. Customise every recipe — image right */}
+          {/* 4. Customise every recipe, image right */}
           <div className="grid lg:grid-cols-2 gap-12 items-center mb-20">
             <div className="space-y-4">
               <h3 className="text-2xl font-bold">
@@ -303,7 +339,7 @@ export default function HomeContent() {
             </div>
           </div>
 
-          {/* 5. Household sharing — image left */}
+          {/* 5. Household sharing, image left */}
           <div className="grid lg:grid-cols-2 gap-12 items-center mb-20">
             <div className="order-2 lg:order-1 relative aspect-16/10 w-full rounded-lg overflow-hidden border border-border">
               <Image
@@ -353,40 +389,52 @@ export default function HomeContent() {
               Get early access
             </h2>
             <p className="text-lg text-muted-foreground mb-2">
-              No credit card. Sign up in seconds, then one click for a full week
-              on your meal plan.
+              Your weekly meal plan and shopping list in one flow. Start with
+              curated meals and add your own anytime.
             </p>
-            <p className="text-sm text-muted-foreground mb-8">
+            <p className="text-sm text-muted-foreground mb-6">
               Free while we&apos;re in beta. We read every bit of feedback.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Authenticated>
-                <Button asChild size="lg" className="text-lg px-8">
-                  <Link href={ROUTES.DASHBOARD}>
-                    Go to dashboard
-                    <ArrowRight className="ml-2 size-5" />
-                  </Link>
-                </Button>
-              </Authenticated>
-              <Unauthenticated>
-                <SignUpButton mode="modal">
-                  <Button
-                    size="lg"
-                    className="text-lg px-8"
-                    onClick={() => {
-                      trackEvent(ANALYTICS_EVENTS.CTA_CLICKED, {
-                        cta_type: "home_footer_join_beta",
-                        intent_topic: "home",
-                      });
-                      trackEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
-                        source_surface: "home_footer",
-                      });
-                    }}
-                  >
-                    Join the beta (free)
-                    <ArrowRight className="ml-2 size-5" />
+            <div className="flex flex-col items-center gap-3">
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Authenticated>
+                  <Button asChild size="lg" className="text-lg px-8">
+                    <Link href={ROUTES.DASHBOARD}>
+                      Go to dashboard
+                      <ArrowRight className="ml-2 size-5" />
+                    </Link>
                   </Button>
-                </SignUpButton>
+                </Authenticated>
+                <Unauthenticated>
+                  <SignUpButton mode="modal">
+                    <Button
+                      size="lg"
+                      className="text-lg px-8"
+                      onClick={() => {
+                        trackEvent(ANALYTICS_EVENTS.CTA_CLICKED, {
+                          cta_type: "home_footer_join_beta",
+                          intent_topic: "home",
+                        });
+                        trackEvent(ANALYTICS_EVENTS.SIGNUP_STARTED, {
+                          source_surface: "home_footer",
+                        });
+                      }}
+                    >
+                      Join free beta
+                      <ArrowRight className="ml-2 size-5" />
+                    </Button>
+                  </SignUpButton>
+                </Unauthenticated>
+              </div>
+              <Unauthenticated>
+                <p className="text-sm text-muted-foreground">
+                  Then generate your week in one click.
+                </p>
+                <div className="flex flex-col sm:flex-row sm:flex-wrap gap-x-6 gap-y-2 justify-center text-sm text-muted-foreground">
+                  <span>Free while in beta</span>
+                  <span>No credit card required</span>
+                  <span>Takes seconds to get started</span>
+                </div>
               </Unauthenticated>
             </div>
           </div>

--- a/src/app/(site)/_components/how-it-plans-section.tsx
+++ b/src/app/(site)/_components/how-it-plans-section.tsx
@@ -7,7 +7,7 @@ export function HowItPlansSection() {
     {
       title: "Generate",
       description:
-        "One click plans your entire week from your recipes. Set the end date and the planner fills the rest.",
+        "One click fills your week from curated picks and recipes you've already saved. Add your own anytime. Set the end date and the planner fills the rest.",
       icon: CalendarPlus,
     },
     {

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -79,8 +79,8 @@ export const metadata: Metadata = {
   },
 };
 
-/** Refresh homepage showcase recipes weekly (Convex-backed). */
-export const revalidate = 60 * 60 * 24 * 7;
+/** Refresh homepage showcase recipes weekly (Convex-backed). Must be a literal for Next.js static analysis. */
+export const revalidate = 604800;
 
 export default async function HomePage() {
   let showcaseRecipes: HomepageShowcaseRecipe[] = [];

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,16 +1,42 @@
 import { APP_NAME, ROUTES } from "@/app/constants";
+import HomeContent from "./_components/home-content";
+import { api } from "convex/_generated/api";
+import { fetchQuery } from "convex/nextjs";
 import { openGraphSiteAndUrl } from "@/lib/og-metadata";
-import { SITE_DEFAULT_OG_IMAGE_ALT, SITE_MISSION } from "@/lib/site-messaging";
+import type { HomepageShowcaseRecipe } from "@/lib/homepage-showcase-recipes";
+import { serializeJsonLd } from "@/lib/json-ld";
+import { SITE_DEFAULT_OG_IMAGE_ALT } from "@/lib/site-messaging";
 import { getSiteBaseUrl } from "@/lib/site-url";
 import type { Metadata } from "next";
-import HomeContent from "./_components/home-content";
 
 const canonicalUrl = `${getSiteBaseUrl()}${ROUTES.HOME}`;
+const siteBase = getSiteBaseUrl();
 
-const homeTitle = `${APP_NAME} - Weekly meal plans in one click (open beta)`;
-const homeDescription = `Open beta: ${SITE_MISSION} Personalised weeks from your recipes: balanced, lists, and household sharing. Free, no card. Feedback welcome.`;
+const homeTitle = `${APP_NAME} - Weekly meal plan & shopping list in one click (open beta)`;
+const homeDescription = `Open beta: weekly meal plan & shopping list in one click with ${APP_NAME}. Curated meals to start; add yours anytime. Household sharing. Free, no card.`;
 
 const homeOgImage = "/hero-2.png";
+
+const homeJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${siteBase}#organization`,
+      name: APP_NAME,
+      url: siteBase,
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${siteBase}#website`,
+      url: siteBase,
+      name: APP_NAME,
+      description: homeDescription,
+      inLanguage: "en-GB",
+      publisher: { "@id": `${siteBase}#organization` },
+    },
+  ],
+};
 
 export const metadata: Metadata = {
   title: {
@@ -18,6 +44,15 @@ export const metadata: Metadata = {
     absolute: homeTitle,
   },
   description: homeDescription,
+  keywords: [
+    APP_NAME,
+    "weekly meal plan",
+    "meal planning",
+    "shopping list",
+    "family meals",
+    "curated recipes",
+    "household",
+  ],
   alternates: {
     canonical: canonicalUrl,
   },
@@ -44,6 +79,29 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HomePage() {
-  return <HomeContent />;
+/** Refresh homepage showcase recipes weekly (Convex-backed). */
+export const revalidate = 60 * 60 * 24 * 7;
+
+export default async function HomePage() {
+  let showcaseRecipes: HomepageShowcaseRecipe[] = [];
+  try {
+    showcaseRecipes = await fetchQuery(
+      api.recipes.getHomepageShowcaseRecipes,
+      { limit: 7 },
+    );
+  } catch {
+    showcaseRecipes = [];
+  }
+
+  const safeJsonLd = serializeJsonLd(homeJsonLd);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd }}
+      />
+      <HomeContent showcaseRecipes={showcaseRecipes} />
+    </>
+  );
 }

--- a/src/lib/homepage-showcase-recipes.ts
+++ b/src/lib/homepage-showcase-recipes.ts
@@ -1,0 +1,15 @@
+/**
+ * Payload from {@link api.recipes.getHomepageShowcaseRecipes} (serialized for the client).
+ */
+export type HomepageShowcaseRecipe = {
+  _id: string;
+  title: string;
+  publicSlug: string | null;
+  image: string | null;
+  prepTime: number;
+  cookTime?: number | null;
+  totalTimeMinutes?: number;
+  category: string;
+  primaryProtein?: string | null;
+  nutrition?: { calories?: number } | null;
+};

--- a/src/lib/site-messaging.ts
+++ b/src/lib/site-messaging.ts
@@ -1,13 +1,13 @@
 import { APP_NAME } from "@/app/constants";
 
-/** Product mission — use in marketing and default meta copy. */
-export const SITE_MISSION = "Weekly meal plans in one click.";
+/** Product mission; used in marketing and default meta copy. */
+export const SITE_MISSION = "Your week of meals, decided in one click.";
 
 /** Default meta description (root layout, site layout, PWA manifest). */
-export const SITE_DEFAULT_DESCRIPTION = `Weekly meal plans in one click with ${APP_NAME}. Save recipes, plan balanced weeks with your household, and generate a shopping list from your plan.`;
+export const SITE_DEFAULT_DESCRIPTION = `${APP_NAME}: decide dinner for the week in one click. Start with curated meals, add your own recipes over time, build a weekly meal plan with your household, and turn it into a shopping list.`;
 
 /** Default browser title when no page-specific title is set. */
-export const SITE_DEFAULT_TITLE = `${APP_NAME} - Weekly meal plans in one click`;
+export const SITE_DEFAULT_TITLE = `${APP_NAME} - Weekly meal plan in one click`;
 
 /** Short alt text for default Open Graph / social preview image. */
-export const SITE_DEFAULT_OG_IMAGE_ALT = `${APP_NAME}. Weekly meal plans in one click.`;
+export const SITE_DEFAULT_OG_IMAGE_ALT = `${APP_NAME}: weekly meal plan and shopping list in one click.`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homepage example week now shows curated recipe cards (images, prep/cook/total times, calories) with responsive swipe/grid layout, plus a linked CTA tile and up to seven showcased recipes.

* **Content Updates**
  * Updated hero and site messaging copy to emphasise deciding your weekly meal plan and shopping list.
  * Added conditional “Browse all curated recipes” link and improved homepage SEO/structured data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->