### PR TITLE
Add meal plan generation controls with subscription-tier gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The repo does not commit a machine-specific `store-dir`. To use a custom pnpm st
 - [x] Improve convex function call usage
 - [x] Remove rabbit meals from system recipes + anything else that might be considered too niche
 - [x] Plan in a premium feature that takes existing ingredients and helps you use them up in your next meal plan (do consider that premium features are free in beta)
-- [ ] Pro tier, public, recipe image generator (need to be very secure and careful on throttling + usage for this one)
-- [ ] Create the premium tier recipe generator (free in beta). We should track which images are AI generated and persist this data to help with preventative re-generation and feature abuse.
+- [x] Pro tier, public, recipe image generator (need to be very secure and careful on throttling + usage for this one)
 - [x] Improve the ingredient manager for superusers: uncategorised ingredients should be searchable, and subcategories should appear alongside categorised ingredients for at-a-glance visibility.
-- Build community and organic traffic, fix bugs. That is all I am allowed to do until the end of the month (April).
+- [ ]Build community and organic traffic, fix bugs. That is all I am allowed to do until the end of the month (April).
+- [ ] Take most popular organic search results in google search console and make sure we have landing pages or blogs to capitalise.
 - [ ] **Super-user recipe generation**: a repeatable flow (UI and/or AI) to propose and land **system-quality** recipes—constraints, meal balance, technique fit, and Convex seed workflow—as codified in [`docs/RECIPE_AUTHORING_METHODOLOGY.md`](docs/RECIPE_AUTHORING_METHODOLOGY.md). Complements batch-style prompts in [`docs/RECIPE-GENERATION-PROMPT.md`](docs/RECIPE-GENERATION-PROMPT.md).
 
 ### Strategic / growth
@@ -106,6 +106,7 @@ _Angle: looking for ~20 testers / feedback._
 
 - [x] Meal plans should be shared to households automatically.
 - [x] When opening the shopping list from the meal plan, Back/Cancel should return to the previous page (not default to recipe selection).
+- [ ] Add basic pre generation controls like no of meals, start date etc. These controls should be UX focused so only a small number of options (3 days, 5 days, 1 week, custom - limit to 7 days max. Start today, tomorrow, following day, custom)
 
 ### Chalkboard and UI friction
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The repo does not commit a machine-specific `store-dir`. To use a custom pnpm st
 - [x] Plan in a premium feature that takes existing ingredients and helps you use them up in your next meal plan (do consider that premium features are free in beta)
 - [x] Pro tier, public, recipe image generator (need to be very secure and careful on throttling + usage for this one)
 - [x] Improve the ingredient manager for superusers: uncategorised ingredients should be searchable, and subcategories should appear alongside categorised ingredients for at-a-glance visibility.
-- [ ]Build community and organic traffic, fix bugs. That is all I am allowed to do until the end of the month (April).
+- [ ] Build community and organic traffic, fix bugs. That is all I am allowed to do until the end of the month (April).
 - [ ] Take most popular organic search results in google search console and make sure we have landing pages or blogs to capitalise.
 - [ ] **Super-user recipe generation**: a repeatable flow (UI and/or AI) to propose and land **system-quality** recipes—constraints, meal balance, technique fit, and Convex seed workflow—as codified in [`docs/RECIPE_AUTHORING_METHODOLOGY.md`](docs/RECIPE_AUTHORING_METHODOLOGY.md). Complements batch-style prompts in [`docs/RECIPE-GENERATION-PROMPT.md`](docs/RECIPE-GENERATION-PROMPT.md).
 
@@ -106,7 +106,7 @@ _Angle: looking for ~20 testers / feedback._
 
 - [x] Meal plans should be shared to households automatically.
 - [x] When opening the shopping list from the meal plan, Back/Cancel should return to the previous page (not default to recipe selection).
-- [ ] Add basic pre generation controls like no of meals, start date etc. These controls should be UX focused so only a small number of options (3 days, 5 days, 1 week, custom - limit to 7 days max. Start today, tomorrow, following day, custom)
+- [x] Add basic pre-generation controls (number of meals, start date, duration) with UX-focused presets: duration — 3 days, 5 days, 1 week, Custom (max 7 days); start date — Today, Tomorrow, Day after, Custom.
 
 ### Chalkboard and UI friction
 

--- a/convex/lib/constants.ts
+++ b/convex/lib/constants.ts
@@ -307,6 +307,26 @@ export function canGenerateRecipeHeroImageWithAI(
   return false;
 }
 
+/** Premium feature: create overlapping/multiple active meal plans. */
+export function canCreateMultipleMealPlans(
+  subscriptionTier: string | undefined,
+): boolean {
+  const tier = subscriptionTier ?? "free_user";
+  if (tier === "pro_user") return true;
+  if (tier === "free_user") return BETA_FREE_INCLUDES_PREMIUM_FEATURES;
+  return false;
+}
+
+/** Premium feature: advanced generation controls for start date and day count. */
+export function canUseAdvancedMealPlanControls(
+  subscriptionTier: string | undefined,
+): boolean {
+  const tier = subscriptionTier ?? "free_user";
+  if (tier === "pro_user") return true;
+  if (tier === "free_user") return BETA_FREE_INCLUDES_PREMIUM_FEATURES;
+  return false;
+}
+
 /** Rate limits for AI recipe image generation (same caps for all entitled tiers during beta). */
 export const RECIPE_AI_HERO_LIMITS = {
   MAX_SUCCEEDED_PER_24H: 5,

--- a/convex/mealPlanGenerator.ts
+++ b/convex/mealPlanGenerator.ts
@@ -73,10 +73,9 @@ export async function buildPool(
     options?.leftoverTargetPhrases,
   );
   const leftoverIdsForMatch = leftoverDocs.map((d) => d._id);
+  const totalLeftoverTargets = leftoverDocs.length + normalisedPhrases.length;
   const leftoverTargetCount =
-    leftoverDocs.length + normalisedPhrases.length > 0
-      ? leftoverDocs.length + normalisedPhrases.length
-      : undefined;
+    totalLeftoverTargets > 0 ? totalLeftoverTargets : undefined;
 
   const addIfEligible = (r: {
     _id: Id<"recipes">;

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -7,6 +7,8 @@ import {
   resolveDefaultHouseholdIdForSharing,
 } from "./households";
 import {
+  canCreateMultipleMealPlans,
+  canUseAdvancedMealPlanControls,
   canUseLeftoverIngredients,
   LEFTOVER_INGREDIENTS_MAX,
   MAX_DAYS_IN_MEAL_PLAN,
@@ -18,13 +20,13 @@ import {
   lineMatchesLeftoverPhrase,
   normaliseLeftoverPhrasesList,
 } from "./lib/leftoverIngredients";
+import type { PoolRecipe } from "./mealPlanGenerator";
 import {
   buildPool,
   getBehaviourStatsForActor,
   getRecentlySuggested,
   selectRecipes,
 } from "./mealPlanGenerator";
-import type { PoolRecipe } from "./mealPlanGenerator";
 import {
   getActorForPlan,
   incrementRemoved,
@@ -52,10 +54,9 @@ function prepareLeftoverInputs(
   totalCount: number;
   wantsLeftovers: boolean;
 } {
-  const ids =
-    rawIds?.filter(Boolean).length
-      ? ([...new Set(rawIds.filter(Boolean))] as Id<"ingredients">[])
-      : [];
+  const ids = rawIds?.filter(Boolean).length
+    ? ([...new Set(rawIds.filter(Boolean))] as Id<"ingredients">[])
+    : [];
   const phrases = normaliseLeftoverPhrasesList(rawPhrases);
   const totalCount = ids.length + phrases.length;
   if (totalCount > LEFTOVER_INGREDIENTS_MAX) {
@@ -79,6 +80,62 @@ function startOfDayMs(ms: number): number {
   const d = new Date(ms);
   d.setUTCHours(0, 0, 0, 0);
   return d.getTime();
+}
+
+function resolveMealPlanWindow(args: {
+  startDate?: number;
+  dayCount?: number;
+  subscriptionTier: string | undefined;
+}): { startDate: number; endDate: number; dayCount: number } {
+  const nowStart = startOfDayMs(Date.now());
+  const isEntitledToAdvancedControls = canUseAdvancedMealPlanControls(
+    args.subscriptionTier,
+  );
+
+  // Server-side source of truth: if advanced controls are not allowed, silently
+  // coerce to standard weekly defaults regardless of client payload.
+  const requestedStart = isEntitledToAdvancedControls
+    ? args.startDate
+      ? startOfDayMs(args.startDate)
+      : nowStart
+    : nowStart;
+  const requestedDayCount = isEntitledToAdvancedControls
+    ? (args.dayCount ?? MAX_DAYS_IN_MEAL_PLAN)
+    : MAX_DAYS_IN_MEAL_PLAN;
+
+  if (requestedDayCount < 1 || requestedDayCount > MAX_DAYS_IN_MEAL_PLAN) {
+    throw new ConvexError(
+      `dayCount must be between 1 and ${MAX_DAYS_IN_MEAL_PLAN}`,
+    );
+  }
+
+  const endDate = startOfDayMs(
+    requestedStart + (requestedDayCount - 1) * ONE_DAY_MS,
+  );
+  return {
+    startDate: requestedStart,
+    endDate,
+    dayCount: requestedDayCount,
+  };
+}
+
+async function assertCanCreateAnotherPlanForUser(
+  ctx: QueryCtx,
+  userId: Id<"users">,
+  subscriptionTier: string | undefined,
+): Promise<void> {
+  if (canCreateMultipleMealPlans(subscriptionTier)) return;
+  const today = startOfDayMs(Date.now());
+  const activeOwnedPlans = await ctx.db
+    .query("mealPlans")
+    .withIndex("by_user_and_endDate", (q) =>
+      q.eq("userId", userId).gte("endDate", today),
+    )
+    .collect();
+  const hasExisting = activeOwnedPlans.some((plan) => !plan.replacedByPlanId);
+  if (hasExisting) {
+    throw new ConvexError("PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS");
+  }
 }
 
 /** Client may omit local day; use UTC “today” start for index bounds and overlap checks. */
@@ -217,11 +274,7 @@ function pickPreferredPlanDoc(
     const finalisedCovering = summaries.filter(
       (s) =>
         s.plan.isFinalised === true &&
-        planOverlapsLocalCalendarDay(
-          s.plan,
-          s.entryMinDate,
-          localDayStartMs,
-        ),
+        planOverlapsLocalCalendarDay(s.plan, s.entryMinDate, localDayStartMs),
     );
     if (finalisedCovering.length > 0) {
       finalisedCovering.sort(
@@ -514,12 +567,22 @@ export const generateWeeklyPlan = mutation({
     leftoverIngredientIds: v.optional(v.array(v.id("ingredients"))),
     /** Optional: free-text leftovers (fuzzy-matched to recipe lines). */
     leftoverIngredientPhrases: v.optional(v.array(v.string())),
+    startDate: v.optional(v.number()),
+    dayCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUserOrThrow(ctx);
     const now = Date.now();
-    const startDate = startOfDayMs(now);
-    const endDate = startOfDayMs(now + MAX_DAYS_IN_MEAL_PLAN * ONE_DAY_MS);
+    const { startDate, endDate, dayCount } = resolveMealPlanWindow({
+      startDate: args.startDate,
+      dayCount: args.dayCount,
+      subscriptionTier: user.subscriptionTier,
+    });
+    await assertCanCreateAnotherPlanForUser(
+      ctx,
+      user._id,
+      user.subscriptionTier,
+    );
 
     const shareHouseholdId = await resolveDefaultHouseholdIdForSharing(
       ctx,
@@ -557,7 +620,7 @@ export const generateWeeklyPlan = mutation({
 
     const selectedIds = selectRecipes(
       pool,
-      MAX_DAYS_IN_MEAL_PLAN,
+      dayCount,
       actorStats,
       generationSeed,
       recentlySuggested,
@@ -571,10 +634,7 @@ export const generateWeeklyPlan = mutation({
     let bestMatchInPool = 0;
     if (wantsLeftovers) {
       for (const p of pool) {
-        bestMatchInPool = Math.max(
-          bestMatchInPool,
-          p.leftoverMatchCount ?? 0,
-        );
+        bestMatchInPool = Math.max(bestMatchInPool, p.leftoverMatchCount ?? 0);
       }
     }
 
@@ -632,12 +692,22 @@ export const createBlankWeeklyPlan = mutation({
   args: {
     /** When omitted: shared if the user belongs to exactly one household; otherwise the new plan is private until they share or pass this field. */
     householdId: v.optional(v.id("households")),
+    startDate: v.optional(v.number()),
+    dayCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUserOrThrow(ctx);
     const now = Date.now();
-    const startDate = startOfDayMs(now);
-    const endDate = startOfDayMs(now + MAX_DAYS_IN_MEAL_PLAN * ONE_DAY_MS);
+    const { startDate, endDate } = resolveMealPlanWindow({
+      startDate: args.startDate,
+      dayCount: args.dayCount,
+      subscriptionTier: user.subscriptionTier,
+    });
+    await assertCanCreateAnotherPlanForUser(
+      ctx,
+      user._id,
+      user.subscriptionTier,
+    );
 
     const shareHouseholdId = await resolveDefaultHouseholdIdForSharing(
       ctx,
@@ -691,9 +761,7 @@ export const regenerateWeeklyPlan = mutation({
 
     let leftoverDocs: Doc<"ingredients">[] = [];
     if (wantsLeftovers && leftover.ids?.length) {
-      const got = await Promise.all(
-        leftover.ids.map((id) => ctx.db.get(id)),
-      );
+      const got = await Promise.all(leftover.ids.map((id) => ctx.db.get(id)));
       leftoverDocs = got.filter((d): d is Doc<"ingredients"> => d != null);
     }
     const normalisedPhraseTargets = normaliseLeftoverPhrasesList(
@@ -725,7 +793,9 @@ export const regenerateWeeklyPlan = mutation({
       generationVersion: 1,
       generatedAt: now,
       householdId: previousPlan.householdId,
-      ...(wantsLeftovers && leftover.ids ? { leftoverIngredientIds: leftover.ids } : {}),
+      ...(wantsLeftovers && leftover.ids
+        ? { leftoverIngredientIds: leftover.ids }
+        : {}),
       ...(wantsLeftovers && leftover.phrases
         ? { leftoverIngredientPhrases: leftover.phrases }
         : {}),
@@ -805,7 +875,8 @@ export const regenerateWeeklyPlan = mutation({
           );
           lockedPoolRecipes.push({
             ...base,
-            leftoverTargetCount: leftoverDocs.length + normalisedPhraseTargets.length,
+            leftoverTargetCount:
+              leftoverDocs.length + normalisedPhraseTargets.length,
             leftoverMatchCount: leftoverMatchKeys.length,
             leftoverMatchKeys,
           });

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -95,13 +95,17 @@ function resolveMealPlanWindow(args: {
   // Server-side source of truth: if advanced controls are not allowed, silently
   // coerce to standard weekly defaults regardless of client payload.
   const requestedStart = isEntitledToAdvancedControls
-    ? args.startDate
+    ? args.startDate !== undefined
       ? startOfDayMs(args.startDate)
       : nowStart
     : nowStart;
   const requestedDayCount = isEntitledToAdvancedControls
     ? (args.dayCount ?? MAX_DAYS_IN_MEAL_PLAN)
     : MAX_DAYS_IN_MEAL_PLAN;
+
+  if (!Number.isInteger(requestedDayCount)) {
+    throw new ConvexError("dayCount must be an integer");
+  }
 
   if (requestedStart < nowStart) {
     throw new ConvexError("startDate cannot be before today");
@@ -558,6 +562,26 @@ export const getActiveMealPlanSummaries = query({
       entryMinDate: s.entryMinDate,
       entryMaxDate: s.entryMaxDate,
     }));
+  },
+});
+
+/**
+ * Count owned plans that would block free-tier additional plan creation:
+ * unreplaced plans with endDate >= today (UTC day start).
+ */
+export const getOwnedUnreplacedPlanCountForCreation = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) return 0;
+    const today = startOfDayMs(Date.now());
+    const ownedPlans = await ctx.db
+      .query("mealPlans")
+      .withIndex("by_user_and_endDate", (q) =>
+        q.eq("userId", user._id).gte("endDate", today),
+      )
+      .collect();
+    return ownedPlans.filter((plan) => !plan.replacedByPlanId).length;
   },
 });
 

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -103,6 +103,16 @@ function resolveMealPlanWindow(args: {
     ? (args.dayCount ?? MAX_DAYS_IN_MEAL_PLAN)
     : MAX_DAYS_IN_MEAL_PLAN;
 
+  if (requestedStart < nowStart) {
+    throw new ConvexError("startDate cannot be before today");
+  }
+  const maxAllowedStart = nowStart + (MAX_DAYS_IN_MEAL_PLAN - 1) * ONE_DAY_MS;
+  if (requestedStart > maxAllowedStart) {
+    throw new ConvexError(
+      `startDate cannot be more than ${MAX_DAYS_IN_MEAL_PLAN - 1} days ahead`,
+    );
+  }
+
   if (requestedDayCount < 1 || requestedDayCount > MAX_DAYS_IN_MEAL_PLAN) {
     throw new ConvexError(
       `dayCount must be between 1 and ${MAX_DAYS_IN_MEAL_PLAN}`,

--- a/src/app/(app)/dashboard/meal-plan/[id]/page.tsx
+++ b/src/app/(app)/dashboard/meal-plan/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import MealPlanClient from "../_components/meal-plan-client";
+
+export const metadata: Metadata = {
+  title: "Meal plan",
+  description: "View and manage a specific meal plan.",
+};
+
+type MealPlanDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function MealPlanDetailPage({
+  params,
+}: MealPlanDetailPageProps) {
+  const { id } = await params;
+
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto animate-pulse space-y-4 px-4 py-8">
+          <div className="h-10 w-64 rounded-md bg-muted" />
+          <div className="h-32 w-full rounded-md bg-muted" />
+        </div>
+      }
+    >
+      <MealPlanClient planId={id} />
+    </Suspense>
+  );
+}

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -48,6 +48,7 @@ import { api } from "convex/_generated/api";
 import { Id } from "convex/_generated/dataModel";
 import {
   canCreateMultipleMealPlans,
+  canUseAdvancedMealPlanControls,
   canUseLeftoverIngredients,
   MAX_DAYS_IN_MEAL_PLAN,
 } from "convex/lib/constants";
@@ -145,6 +146,9 @@ export default function MealPlanClient({
   const planSummaries = useQuery(api.mealPlans.getActiveMealPlanSummaries, {
     localDayStartMs,
   });
+  const ownedPlanCountForCreation = useQuery(
+    api.mealPlans.getOwnedUnreplacedPlanCountForCreation,
+  );
 
   const resolvedPlanId = useMemo(() => {
     if (generationOnly) return null;
@@ -299,13 +303,14 @@ export default function MealPlanClient({
   const canUseMealPlanLeftovers =
     currentUser != null &&
     canUseLeftoverIngredients(currentUser.subscriptionTier);
-  const hasActivePlan = (planSummaries?.length ?? 0) > 0;
+  const hasActivePlan = (ownedPlanCountForCreation ?? 0) > 0;
   const blocksAdditionalPlansOnFreeTier =
     currentUser != null &&
     hasActivePlan &&
     !canCreateMultipleMealPlans(currentUser.subscriptionTier);
-  // Keep this aligned with premium-beta rollout semantics used by leftovers.
-  const canUseAdvancedControls = canUseMealPlanLeftovers;
+  const canUseAdvancedControls =
+    currentUser != null &&
+    canUseAdvancedMealPlanControls(currentUser.subscriptionTier);
   const controlsReady = currentUser !== undefined;
   const controlsLocked = controlsReady && !canUseAdvancedControls;
 

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ROUTES } from "@/app/constants";
+import { PremiumFeatureNotice } from "@/components/premium-feature-notice";
 import { LeftoverIngredientsPicker } from "@/components/recipes/leftover-ingredients-picker";
 import {
   AlertDialog,
@@ -41,26 +42,34 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { trackEvent } from "@/lib/analytics/posthog-client";
 import { pickPreferredMealPlanIdFromSummaries } from "@/lib/meal-plan-preference";
+import { navigateBackOr } from "@/lib/navigation";
 import { cn, startOfLocalDayMs } from "@/lib/utils";
 import { api } from "convex/_generated/api";
 import { Id } from "convex/_generated/dataModel";
-import { canUseLeftoverIngredients } from "convex/lib/constants";
+import {
+  canCreateMultipleMealPlans,
+  canUseLeftoverIngredients,
+  MAX_DAYS_IN_MEAL_PLAN,
+} from "convex/lib/constants";
 import { useMutation, useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import {
+  ArrowLeft,
   ArrowRight,
   CalendarPlus,
   CheckCircle2,
   Home,
+  Loader2,
   MoreVertical,
   ShoppingCart,
+  SlidersHorizontal,
   Sparkles,
   Trash2,
   UserMinus,
   Users,
 } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EmptySlot } from "./empty-slot";
@@ -85,6 +94,17 @@ function mealPlanGenerateFailureReason(e: unknown): string {
   }
   return "unknown_error";
 }
+
+function mealPlanErrorMessage(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e);
+  if (/PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS/i.test(msg)) {
+    return "Multiple active meal plans are a premium feature. Upgrade to create another plan.";
+  }
+  if (/PREMIUM_REQUIRED_ADVANCED_MEAL_PLAN_CONTROLS/i.test(msg)) {
+    return "Custom start dates and day lengths are premium controls.";
+  }
+  return msg;
+}
 const MEAL_PLAN_EMPTY_VIEWED_SESSION_KEY =
   "foodedo_onboarding_meal_plan_empty_viewed";
 
@@ -103,13 +123,22 @@ function formatPlanRangeShort(start: number | undefined, end: number): string {
   return fmt(end);
 }
 
-export default function MealPlanClient() {
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+type MealPlanClientProps = {
+  planId?: string;
+  generationOnly?: boolean;
+};
+
+export default function MealPlanClient({
+  planId,
+  generationOnly = false,
+}: MealPlanClientProps) {
   const emptyViewedTrackedRef = useRef(false);
 
   const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const planParam = searchParams.get("plan");
+  const planParam = planId ?? searchParams.get("plan");
 
   const localDayStartMs = startOfLocalDayMs(Date.now());
 
@@ -118,6 +147,7 @@ export default function MealPlanClient() {
   });
 
   const resolvedPlanId = useMemo(() => {
+    if (generationOnly) return null;
     if (planSummaries === undefined) return undefined;
     if (planSummaries.length === 0) return null;
 
@@ -132,28 +162,40 @@ export default function MealPlanClient() {
       }
     }
     return pickPreferredMealPlanIdFromSummaries(planSummaries, localDayStartMs);
-  }, [planSummaries, planParam, localDayStartMs]);
+  }, [generationOnly, planSummaries, planParam, localDayStartMs]);
 
   useEffect(() => {
+    if (generationOnly) return;
+    if (planId) {
+      if (resolvedPlanId && typeof window !== "undefined") {
+        sessionStorage.setItem(
+          MEAL_PLAN_LAST_VIEWED_STORAGE_KEY,
+          resolvedPlanId,
+        );
+      }
+      return;
+    }
     if (planSummaries === undefined) return;
 
     if (planSummaries.length === 0) {
-      if (planParam) {
-        router.replace(pathname, { scroll: false });
-      }
       return;
     }
 
     if (resolvedPlanId && planParam !== resolvedPlanId) {
-      router.replace(`${pathname}?plan=${encodeURIComponent(resolvedPlanId)}`, {
-        scroll: false,
-      });
+      router.replace(ROUTES.mealPlanWithId(resolvedPlanId), { scroll: false });
     }
 
     if (resolvedPlanId && typeof window !== "undefined") {
       sessionStorage.setItem(MEAL_PLAN_LAST_VIEWED_STORAGE_KEY, resolvedPlanId);
     }
-  }, [planSummaries, planParam, resolvedPlanId, pathname, router]);
+  }, [
+    generationOnly,
+    planId,
+    planSummaries,
+    planParam,
+    resolvedPlanId,
+    router,
+  ]);
 
   useEffect(() => {
     if (planSummaries === undefined || planSummaries.length > 0) return;
@@ -259,6 +301,52 @@ export default function MealPlanClient() {
   const canUseMealPlanLeftovers =
     currentUser != null &&
     canUseLeftoverIngredients(currentUser.subscriptionTier);
+  const hasActivePlan = (planSummaries?.length ?? 0) > 0;
+  const blocksAdditionalPlansOnFreeTier =
+    currentUser != null &&
+    hasActivePlan &&
+    !canCreateMultipleMealPlans(currentUser.subscriptionTier);
+  // Keep this aligned with premium-beta rollout semantics used by leftovers.
+  const canUseAdvancedControls = canUseMealPlanLeftovers;
+  const controlsReady = currentUser !== undefined;
+  const controlsLocked = controlsReady && !canUseAdvancedControls;
+
+  const [dayOption, setDayOption] = useState<"3" | "5" | "7" | "custom">("7");
+  const [customDayCount, setCustomDayCount] = useState("7");
+  const [startDateOption, setStartDateOption] = useState<
+    "today" | "tomorrow" | "following" | "custom"
+  >("today");
+  const [customStartDate, setCustomStartDate] = useState("");
+
+  const selectedDayCount = useMemo(() => {
+    if (controlsLocked) return 7;
+    if (dayOption === "custom") {
+      const parsed = Number.parseInt(customDayCount, 10);
+      if (Number.isNaN(parsed)) return 7;
+      return Math.max(1, Math.min(MAX_DAYS_IN_MEAL_PLAN, parsed));
+    }
+    return Number.parseInt(dayOption, 10);
+  }, [controlsLocked, customDayCount, dayOption]);
+
+  const selectedStartDate = useMemo(() => {
+    if (controlsLocked) return localDayStartMs;
+    if (startDateOption === "today") return localDayStartMs;
+    if (startDateOption === "tomorrow") return localDayStartMs + ONE_DAY_MS;
+    if (startDateOption === "following")
+      return localDayStartMs + 2 * ONE_DAY_MS;
+    if (!customStartDate) return localDayStartMs;
+    const parsed = new Date(`${customStartDate}T00:00:00`).getTime();
+    return Number.isNaN(parsed) ? localDayStartMs : parsed;
+  }, [controlsLocked, customStartDate, localDayStartMs, startDateOption]);
+
+  const followingDayLabel = useMemo(() => {
+    const followingDayMs = localDayStartMs + 2 * ONE_DAY_MS;
+    return new Date(followingDayMs).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+  }, [localDayStartMs]);
 
   useEffect(() => {
     if (currentUser === undefined) return;
@@ -298,6 +386,8 @@ export default function MealPlanClient() {
         householdId?: Id<"households">;
         leftoverIngredientIds?: Id<"ingredients">[];
         leftoverIngredientPhrases?: string[];
+        startDate?: number;
+        dayCount?: number;
       } =
         households.length > 1
           ? {
@@ -306,6 +396,8 @@ export default function MealPlanClient() {
                 households[0]!._id,
             }
           : {};
+      payload.startDate = selectedStartDate;
+      payload.dayCount = selectedDayCount;
       if (
         canUseMealPlanLeftovers &&
         (mealPlanLeftoverIds.length > 0 || mealPlanLeftoverPhrases.length > 0)
@@ -337,7 +429,7 @@ export default function MealPlanClient() {
         );
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "Failed to generate plan";
+      const msg = mealPlanErrorMessage(e) || "Failed to generate plan";
       trackEvent(ANALYTICS_EVENTS.MEAL_PLAN_GENERATE_FAILED, {
         error_reason: mealPlanGenerateFailureReason(e),
       });
@@ -363,6 +455,8 @@ export default function MealPlanClient() {
     mealPlanLeftoverIds,
     mealPlanLeftoverPhrases,
     router,
+    selectedDayCount,
+    selectedStartDate,
   ]);
 
   const handleBlankWeek = useCallback(async () => {
@@ -380,7 +474,11 @@ export default function MealPlanClient() {
                 households[0]!._id,
             }
           : {};
-      const { planId } = await createBlankWeeklyPlan(payload);
+      const { planId } = await createBlankWeeklyPlan({
+        ...payload,
+        startDate: selectedStartDate,
+        dayCount: selectedDayCount,
+      });
       trackEvent(ANALYTICS_EVENTS.MEAL_PLAN_BLANK_CREATED, {
         shared_with_household: households.length > 1,
       });
@@ -390,13 +488,18 @@ export default function MealPlanClient() {
       router.push(ROUTES.mealPlanWithId(planId));
       toast.success("Manual plan ready. Add your meals.");
     } catch (e) {
-      toast.error(
-        e instanceof Error ? e.message : "Failed to create manual plan",
-      );
+      toast.error(mealPlanErrorMessage(e) || "Failed to create manual plan");
     } finally {
       setIsGenerating(false);
     }
-  }, [createBlankWeeklyPlan, generateWeekHouseholdId, households, router]);
+  }, [
+    createBlankWeeklyPlan,
+    generateWeekHouseholdId,
+    households,
+    router,
+    selectedDayCount,
+    selectedStartDate,
+  ]);
 
   const handleRegenerateWeek = useCallback(async () => {
     if (!currentPlan) return;
@@ -671,15 +774,18 @@ export default function MealPlanClient() {
   }, [personalChalkboard, householdChalkboards, households]);
 
   useEffect(() => {
+    if (generationOnly) return;
     if (!resolvedPlanId || currentPlan === undefined) return;
     if (currentPlan === null && planParam) {
       router.replace(ROUTES.MEAL_PLAN, { scroll: false });
     }
-  }, [resolvedPlanId, currentPlan, router, planParam]);
+  }, [generationOnly, resolvedPlanId, currentPlan, router, planParam]);
 
   const isPlanListLoading =
-    planSummaries === undefined || resolvedPlanId === undefined;
+    planSummaries === undefined ||
+    (!generationOnly && resolvedPlanId === undefined);
   const isPlanDetailLoading =
+    !generationOnly &&
     resolvedPlanId !== null &&
     resolvedPlanId !== undefined &&
     currentPlan === undefined;
@@ -690,6 +796,270 @@ export default function MealPlanClient() {
         <Skeleton className="h-10 w-64 mb-4" />
         <Skeleton className="h-32 w-full mb-4" />
         <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (generationOnly) {
+    return (
+      <div className="bg-background w-full min-w-0 overflow-x-hidden">
+        <div className="container mx-auto px-4 py-8">
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-bold text-foreground mb-2">
+                Your Weekly Plan
+              </h1>
+              <p className="text-muted-foreground text-base sm:text-lg">
+                Pick your timing, then generate a dedicated meal plan page.
+              </p>
+            </div>
+          </div>
+          {planSummaries.length > 0 ? (
+            <Card className="mb-6 max-w-2xl mx-auto">
+              <CardContent className="p-5 space-y-3">
+                <h2 className="font-semibold text-lg">Your Meal Plans</h2>
+                <div className="space-y-2">
+                  {planSummaries.map((summary) => (
+                    <Button
+                      key={summary._id}
+                      variant="outline"
+                      className="w-full justify-between"
+                      onClick={() =>
+                        router.push(ROUTES.mealPlanWithId(summary._id))
+                      }
+                    >
+                      <span>
+                        {formatPlanRangeShort(
+                          summary.startDate,
+                          summary.endDate,
+                        )}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {summary.isFinalised ? "Saved" : "Draft"}
+                      </span>
+                    </Button>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
+          <Card className="mb-6 border-border/80 bg-muted/20">
+            <CardContent className="p-3 space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <SlidersHorizontal
+                  className="size-4 shrink-0 text-primary"
+                  aria-hidden
+                />
+                <h2 className="text-base font-semibold text-foreground">
+                  Meal plan controls
+                </h2>
+                <Badge
+                  variant="secondary"
+                  className="text-[10px] font-semibold uppercase"
+                >
+                  Pro
+                </Badge>
+              </div>
+              {controlsLocked ? (
+                <PremiumFeatureNotice
+                  title="Pro feature"
+                  description="You can preview these options now."
+                />
+              ) : null}
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-foreground">Days</p>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {(["3", "5", "7", "custom"] as const).map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      disabled={controlsLocked}
+                      onClick={() => setDayOption(option)}
+                      className={cn(
+                        "rounded-lg border px-3 py-3 text-left text-sm transition-colors",
+                        dayOption === option
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-card text-muted-foreground",
+                        controlsLocked && "cursor-not-allowed opacity-60",
+                      )}
+                    >
+                      {option === "custom" ? "Custom" : `${option} days`}
+                    </button>
+                  ))}
+                </div>
+                {dayOption === "custom" ? (
+                  <div className="max-w-40">
+                    <Label htmlFor="custom-day-count" className="text-xs">
+                      Custom days (max 7)
+                    </Label>
+                    <input
+                      id="custom-day-count"
+                      type="number"
+                      min={1}
+                      max={MAX_DAYS_IN_MEAL_PLAN}
+                      placeholder="1-7"
+                      value={customDayCount}
+                      onChange={(e) => setCustomDayCount(e.target.value)}
+                      disabled={controlsLocked}
+                      className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                    />
+                  </div>
+                ) : null}
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-foreground">Starts</p>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {(
+                    [
+                      ["today", "Today"],
+                      ["tomorrow", "Tomorrow"],
+                      ["following", followingDayLabel],
+                      ["custom", "Custom date"],
+                    ] as const
+                  ).map(([option, label]) => (
+                    <button
+                      key={option}
+                      type="button"
+                      disabled={controlsLocked}
+                      onClick={() => setStartDateOption(option)}
+                      className={cn(
+                        "rounded-lg border px-3 py-3 text-left text-sm transition-colors",
+                        startDateOption === option
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-card text-muted-foreground",
+                        controlsLocked && "cursor-not-allowed opacity-60",
+                      )}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                {startDateOption === "custom" ? (
+                  <div className="max-w-56">
+                    <Label htmlFor="custom-start-date" className="text-xs">
+                      Custom start date
+                    </Label>
+                    <input
+                      id="custom-start-date"
+                      type="date"
+                      title="Custom start date"
+                      value={customStartDate}
+                      onChange={(e) => setCustomStartDate(e.target.value)}
+                      disabled={controlsLocked}
+                      className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                    />
+                  </div>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+          <div className="max-w-2xl mx-auto mb-6 w-full">
+            <LeftoverIngredientsPicker
+              selectedIds={mealPlanLeftoverIds}
+              selectedPhrases={mealPlanLeftoverPhrases}
+              onSelectionChange={({ ingredientIds, phrases }) => {
+                setMealPlanLeftoverIds(ingredientIds);
+                setMealPlanLeftoverPhrases(phrases);
+              }}
+              canUseFeatures={canUseMealPlanLeftovers}
+              description="Optional: prioritise recipes that use ingredients you want to finish this week."
+            />
+          </div>
+          <Card className="border-2 border-dashed border-muted-foreground/25 bg-card p-8 sm:p-10 text-center max-w-xl mx-auto">
+            <CardContent className="p-0 flex flex-col items-center">
+              <div className="size-16 rounded-full border-2 border-primary/30 bg-primary/10 flex items-center justify-center mb-6">
+                <Sparkles className="size-8 text-primary" />
+              </div>
+              <h2 className="text-xl sm:text-2xl font-bold text-foreground mb-2">
+                Ready to eat better?
+              </h2>
+              <p className="text-muted-foreground mb-3 max-w-sm mx-auto">
+                We pick from the curated catalog plus your library so you get a
+                full week in seconds.
+              </p>
+              <p className="text-muted-foreground text-sm mb-6 max-w-sm mx-auto">
+                Prefer to pick every meal yourself? Start a manual plan with
+                empty days, then fill them in.
+              </p>
+              {households && households.length > 1 ? (
+                <div className="mb-4 w-full max-w-sm text-left space-y-1.5">
+                  <Label htmlFor="empty-gen-household">Household</Label>
+                  <Select
+                    value={generateWeekHouseholdId || households[0]?._id || ""}
+                    onValueChange={(v) =>
+                      setGenerateWeekHouseholdId(v as Id<"households">)
+                    }
+                  >
+                    <SelectTrigger id="empty-gen-household">
+                      <SelectValue placeholder="Select household" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {households.map((h) => (
+                        <SelectItem key={h._id} value={h._id}>
+                          {h.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+              <div className="flex w-full max-w-sm mx-auto flex-col gap-2 sm:flex-row sm:justify-center">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="w-full sm:flex-1"
+                  onClick={handleBlankWeek}
+                  disabled={
+                    isGenerating ||
+                    households === undefined ||
+                    blocksAdditionalPlansOnFreeTier
+                  }
+                >
+                  {isGenerating ? (
+                    <Loader2 className="size-5 mr-2 animate-spin" />
+                  ) : (
+                    <CalendarPlus className="size-5 mr-2" />
+                  )}
+                  Manual plan
+                </Button>
+                <Button
+                  size="lg"
+                  className="w-full sm:flex-1"
+                  onClick={handleGenerateWeek}
+                  disabled={
+                    isGenerating ||
+                    households === undefined ||
+                    blocksAdditionalPlansOnFreeTier
+                  }
+                >
+                  {isGenerating ? (
+                    <Loader2 className="size-5 mr-2 animate-spin" />
+                  ) : (
+                    <Sparkles className="size-5 mr-2" />
+                  )}
+                  {isGenerating ? "Generating..." : "Generate My Week"}
+                  {!isGenerating ? (
+                    <ArrowRight className="size-5 ml-2" />
+                  ) : null}
+                </Button>
+              </div>
+              {blocksAdditionalPlansOnFreeTier ? (
+                <p className="mt-3 max-w-sm text-xs text-muted-foreground">
+                  Free users can only have one active meal plan at a time. If
+                  you want to create another meal plan, delete your existing one
+                  first, or{" "}
+                  <Link
+                    href={ROUTES.PRICING}
+                    className="underline underline-offset-4"
+                  >
+                    upgrade your account
+                  </Link>{" "}
+                  to enable multiple meal plans.
+                </p>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
       </div>
     );
   }
@@ -837,74 +1207,18 @@ export default function MealPlanClient() {
           !isFinalised && currentPlan.isOwner ? "pb-36" : "pb-20",
         )}
       >
-        {/* Top bar: always show Generate meal plan so user can generate next week early */}
-        {currentPlan.isOwner && (
-          <div className="mb-4 flex flex-col sm:flex-row flex-wrap items-stretch sm:items-center gap-2">
-            {households && households.length > 1 ? (
-              <div className="flex flex-col gap-1.5 sm:max-w-xs">
-                <Label
-                  htmlFor="top-gen-household"
-                  className="text-xs text-muted-foreground"
-                >
-                  Next week · household
-                </Label>
-                <Select
-                  value={generateWeekHouseholdId || households[0]?._id || ""}
-                  onValueChange={(v) =>
-                    setGenerateWeekHouseholdId(v as Id<"households">)
-                  }
-                >
-                  <SelectTrigger id="top-gen-household" size="sm">
-                    <SelectValue placeholder="Household" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {households.map((h) => (
-                      <SelectItem key={h._id} value={h._id}>
-                        {h.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            ) : null}
-            <div className="flex flex-wrap gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleBlankWeek}
-                disabled={isGenerating || households === undefined}
-                className="shrink-0"
-              >
-                <CalendarPlus className="size-4" />
-                Manual plan
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleGenerateWeek}
-                disabled={isGenerating || households === undefined}
-                className="shrink-0"
-              >
-                <Sparkles className="size-4" />
-                Generate next plan
-              </Button>
-            </div>
-          </div>
-        )}
-        {currentPlan.isOwner && (
-          <div className="mb-4 max-w-2xl">
-            <LeftoverIngredientsPicker
-              selectedIds={mealPlanLeftoverIds}
-              selectedPhrases={mealPlanLeftoverPhrases}
-              onSelectionChange={({ ingredientIds, phrases }) => {
-                setMealPlanLeftoverIds(ingredientIds);
-                setMealPlanLeftoverPhrases(phrases);
-              }}
-              canUseFeatures={canUseMealPlanLeftovers}
-              description="Optional: prioritise recipes that use ingredients you want to finish this week. Applies when you generate or regenerate."
-            />
-          </div>
-        )}
+        <div className="mb-4">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => navigateBackOr(router, ROUTES.MEAL_PLAN)}
+            aria-label="Go back to meal plan generation"
+          >
+            <ArrowLeft className="size-4" />
+            Back
+          </Button>
+        </div>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4 sm:mb-6 min-w-0">
           <div className="min-w-0 overflow-hidden">
             <h1 className="text-2xl sm:text-4xl font-bold text-foreground mb-2 truncate">
@@ -1133,19 +1447,15 @@ export default function MealPlanClient() {
         </AlertDialog>
 
         {sharedHousehold && (
-          <Card className="mb-6 border-primary/25 bg-primary/5">
-            <CardContent className="py-4 px-4 flex gap-3 items-start">
+          <Card className="mb-4 py-4 border-primary/25 bg-primary/5">
+            <CardContent className="px-3 flex gap-2 items-center">
               <div className="mt-0.5 rounded-md bg-primary/15 p-1.5 shrink-0">
                 <Home className="size-4 text-primary" />
               </div>
-              <div className="min-w-0 space-y-1.5 text-sm">
-                <p className="font-medium text-foreground">
+              <div className="min-w-0 text-sm">
+                <p className="font-medium text-foreground leading-none">
                   Shared with{" "}
                   <span className="text-primary">{sharedHousehold.name}</span>
-                </p>
-                <p className="text-muted-foreground leading-relaxed">
-                  Everyone in this household can see this plan and shop from it,
-                  including new weeks you generate.{" "}
                 </p>
               </div>
             </CardContent>

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -148,13 +148,11 @@ export default function MealPlanClient({
 
   const resolvedPlanId = useMemo(() => {
     if (generationOnly) return null;
+    if (planParam) return planParam as Id<"mealPlans">;
     if (planSummaries === undefined) return undefined;
     if (planSummaries.length === 0) return null;
 
     const validIds = new Set(planSummaries.map((s) => s._id));
-    if (planParam && validIds.has(planParam as Id<"mealPlans">)) {
-      return planParam as Id<"mealPlans">;
-    }
     if (typeof window !== "undefined") {
       const last = sessionStorage.getItem(MEAL_PLAN_LAST_VIEWED_STORAGE_KEY);
       if (last && validIds.has(last as Id<"mealPlans">)) {
@@ -329,14 +327,30 @@ export default function MealPlanClient({
   }, [controlsLocked, customDayCount, dayOption]);
 
   const selectedStartDate = useMemo(() => {
-    if (controlsLocked) return localDayStartMs;
-    if (startDateOption === "today") return localDayStartMs;
-    if (startDateOption === "tomorrow") return localDayStartMs + ONE_DAY_MS;
-    if (startDateOption === "following")
-      return localDayStartMs + 2 * ONE_DAY_MS;
-    if (!customStartDate) return localDayStartMs;
-    const parsed = new Date(`${customStartDate}T00:00:00`).getTime();
-    return Number.isNaN(parsed) ? localDayStartMs : parsed;
+    const utcStartForLocalDate = (offsetDays: number): number => {
+      const local = new Date(localDayStartMs);
+      local.setDate(local.getDate() + offsetDays);
+      return Date.UTC(local.getFullYear(), local.getMonth(), local.getDate());
+    };
+
+    if (controlsLocked) return utcStartForLocalDate(0);
+    if (startDateOption === "today") return utcStartForLocalDate(0);
+    if (startDateOption === "tomorrow") return utcStartForLocalDate(1);
+    if (startDateOption === "following") return utcStartForLocalDate(2);
+    if (!customStartDate) return utcStartForLocalDate(0);
+
+    const [year, month, day] = customStartDate.split("-").map(Number);
+    if (
+      Number.isNaN(year) ||
+      Number.isNaN(month) ||
+      Number.isNaN(day) ||
+      year <= 0 ||
+      month <= 0 ||
+      day <= 0
+    ) {
+      return utcStartForLocalDate(0);
+    }
+    return Date.UTC(year, month - 1, day);
   }, [controlsLocked, customStartDate, localDayStartMs, startDateOption]);
 
   const followingDayLabel = useMemo(() => {
@@ -367,9 +381,19 @@ export default function MealPlanClient({
     );
   }, [currentPlan?.entries]);
 
+  const visiblePlanDays = useMemo(() => {
+    if (!currentPlan) return selectedDayCount;
+    if (currentPlan.startDate !== undefined) {
+      const computedDays =
+        Math.floor((currentPlan.endDate - currentPlan.startDate) / ONE_DAY_MS) + 1;
+      return Math.max(1, computedDays);
+    }
+    return selectedDayCount;
+  }, [currentPlan, selectedDayCount]);
+
   const emptySlotsCount = useMemo(
-    () => Math.max(0, 7 - (currentPlan?.entries?.length ?? 0)),
-    [currentPlan?.entries?.length],
+    () => Math.max(0, visiblePlanDays - (currentPlan?.entries?.length ?? 0)),
+    [currentPlan?.entries?.length, visiblePlanDays],
   );
 
   const handleGenerateWeek = useCallback(async () => {

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -101,6 +101,9 @@ function mealPlanErrorMessage(e: unknown): string {
   if (/PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS/i.test(msg)) {
     return "Multiple active meal plans are a premium feature. Upgrade to create another plan.";
   }
+  if (/PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS/i.test(msg)) {
+    return "Leftover-ingredient management is a premium feature. Upgrade to enable it.";
+  }
   if (/PREMIUM_REQUIRED_ADVANCED_MEAL_PLAN_CONTROLS/i.test(msg)) {
     return "Custom start dates and day lengths are premium controls.";
   }
@@ -300,19 +303,24 @@ export default function MealPlanClient({
   const [mealPlanLeftoverPhrases, setMealPlanLeftoverPhrases] = useState<
     string[]
   >([]);
+  const entitlementsReady =
+    currentUser !== undefined && ownedPlanCountForCreation !== undefined;
   const canUseMealPlanLeftovers =
+    entitlementsReady &&
     currentUser != null &&
     canUseLeftoverIngredients(currentUser.subscriptionTier);
-  const hasActivePlan = (ownedPlanCountForCreation ?? 0) > 0;
+  const hasActivePlan =
+    entitlementsReady && (ownedPlanCountForCreation ?? 0) > 0;
   const blocksAdditionalPlansOnFreeTier =
+    entitlementsReady &&
     currentUser != null &&
     hasActivePlan &&
     !canCreateMultipleMealPlans(currentUser.subscriptionTier);
   const canUseAdvancedControls =
+    entitlementsReady &&
     currentUser != null &&
     canUseAdvancedMealPlanControls(currentUser.subscriptionTier);
-  const controlsReady = currentUser !== undefined;
-  const controlsLocked = controlsReady && !canUseAdvancedControls;
+  const controlsLocked = !entitlementsReady || !canUseAdvancedControls;
 
   const [dayOption, setDayOption] = useState<"3" | "5" | "7" | "custom">("7");
   const [customDayCount, setCustomDayCount] = useState("7");
@@ -390,7 +398,8 @@ export default function MealPlanClient({
     if (!currentPlan) return selectedDayCount;
     if (currentPlan.startDate !== undefined) {
       const computedDays =
-        Math.floor((currentPlan.endDate - currentPlan.startDate) / ONE_DAY_MS) + 1;
+        Math.floor((currentPlan.endDate - currentPlan.startDate) / ONE_DAY_MS) +
+        1;
       return Math.max(1, computedDays);
     }
     return selectedDayCount;
@@ -402,6 +411,12 @@ export default function MealPlanClient({
   );
 
   const handleGenerateWeek = useCallback(async () => {
+    if (blocksAdditionalPlansOnFreeTier) {
+      toast.error(
+        "Free users can only have one active meal plan at a time. Delete your existing plan or upgrade to create another.",
+      );
+      return;
+    }
     if (households === undefined) {
       toast.info("Loading households…");
       return;
@@ -486,9 +501,16 @@ export default function MealPlanClient({
     router,
     selectedDayCount,
     selectedStartDate,
+    blocksAdditionalPlansOnFreeTier,
   ]);
 
   const handleBlankWeek = useCallback(async () => {
+    if (blocksAdditionalPlansOnFreeTier) {
+      toast.error(
+        "Free users can only have one active meal plan at a time. Delete your existing plan or upgrade to create another.",
+      );
+      return;
+    }
     if (households === undefined) {
       toast.info("Loading households…");
       return;
@@ -528,6 +550,7 @@ export default function MealPlanClient({
     router,
     selectedDayCount,
     selectedStartDate,
+    blocksAdditionalPlansOnFreeTier,
   ]);
 
   const handleRegenerateWeek = useCallback(async () => {
@@ -1041,7 +1064,8 @@ export default function MealPlanClient({
                   disabled={
                     isGenerating ||
                     households === undefined ||
-                    blocksAdditionalPlansOnFreeTier
+                    blocksAdditionalPlansOnFreeTier ||
+                    !entitlementsReady
                   }
                 >
                   {isGenerating ? (
@@ -1058,7 +1082,8 @@ export default function MealPlanClient({
                   disabled={
                     isGenerating ||
                     households === undefined ||
-                    blocksAdditionalPlansOnFreeTier
+                    blocksAdditionalPlansOnFreeTier ||
+                    !entitlementsReady
                   }
                 >
                   {isGenerating ? (
@@ -1187,7 +1212,12 @@ export default function MealPlanClient({
                   variant="outline"
                   className="w-full sm:flex-1"
                   onClick={handleBlankWeek}
-                  disabled={isGenerating || households === undefined}
+                  disabled={
+                    isGenerating ||
+                    households === undefined ||
+                    blocksAdditionalPlansOnFreeTier ||
+                    !entitlementsReady
+                  }
                 >
                   <CalendarPlus className="size-5 mr-2" />
                   Manual plan
@@ -1196,7 +1226,12 @@ export default function MealPlanClient({
                   size="lg"
                   className="w-full sm:flex-1"
                   onClick={handleGenerateWeek}
-                  disabled={isGenerating || households === undefined}
+                  disabled={
+                    isGenerating ||
+                    households === undefined ||
+                    blocksAdditionalPlansOnFreeTier ||
+                    !entitlementsReady
+                  }
                 >
                   Start Planning
                   <ArrowRight className="size-5 ml-2" />

--- a/src/app/(app)/dashboard/meal-plan/page.tsx
+++ b/src/app/(app)/dashboard/meal-plan/page.tsx
@@ -1,6 +1,7 @@
-import { Metadata } from "next";
-import { Suspense } from "react";
 import { SITE_MISSION } from "@/lib/site-messaging";
+import { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import MealPlanClient from "./_components/meal-plan-client";
 
 export const metadata: Metadata = {
@@ -8,7 +9,18 @@ export const metadata: Metadata = {
   description: `${SITE_MISSION} Then adjust, share, and generate a shopping list.`,
 };
 
-export default function MealPlanPage() {
+type MealPlanPageProps = {
+  searchParams: Promise<{ plan?: string }>;
+};
+
+export default async function MealPlanPage({
+  searchParams,
+}: MealPlanPageProps) {
+  const { plan } = await searchParams;
+  if (plan) {
+    redirect(`/dashboard/meal-plan/${encodeURIComponent(plan)}`);
+  }
+
   return (
     <Suspense
       fallback={
@@ -18,7 +30,7 @@ export default function MealPlanPage() {
         </div>
       }
     >
-      <MealPlanClient />
+      <MealPlanClient generationOnly />
     </Suspense>
   );
 }

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -29,7 +29,7 @@ export const ROUTES = {
   MEAL_PLAN: "/dashboard/meal-plan",
   /** Meal plan screen with a specific plan selected */
   mealPlanWithId: (planId: string) =>
-    `/dashboard/meal-plan?plan=${encodeURIComponent(planId)}`,
+    `/dashboard/meal-plan/${encodeURIComponent(planId)}`,
   SHOPPING_LIST: "/dashboard/shopping-list",
   /** URL for a specific shopping list (use with query param listId) */
   shoppingListWithId: (listId: string) =>

--- a/src/components/premium-feature-notice.tsx
+++ b/src/components/premium-feature-notice.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { ROUTES } from "@/app/constants";
+import { cn } from "@/lib/utils";
+import { Lock } from "lucide-react";
+import Link from "next/link";
+
+type PremiumFeatureNoticeProps = {
+  title: string;
+  description: string;
+  className?: string;
+};
+
+export function PremiumFeatureNotice({
+  title,
+  description,
+  className,
+}: PremiumFeatureNoticeProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border bg-background/60 p-3 text-sm",
+        className,
+      )}
+    >
+      <p className="font-medium flex items-center gap-2">
+        <Lock className="size-4" />
+        {title}
+      </p>
+      <p className="mt-1 text-muted-foreground">
+        {description}{" "}
+        <Link className="underline underline-offset-4" href={ROUTES.PRICING}>
+          Upgrade your account
+        </Link>{" "}
+        to take advantage of advanced features.
+      </p>
+    </div>
+  );
+}

--- a/src/components/recipes/leftover-ingredients-picker.tsx
+++ b/src/components/recipes/leftover-ingredients-picker.tsx
@@ -144,7 +144,7 @@ export function LeftoverIngredientsPicker({
         {locked ? (
           <PremiumFeatureNotice
             title="Use up ingredients is premium"
-            description="You can preview this feature now. Upgrade on"
+            description="You can preview this feature now."
           />
         ) : null}
 

--- a/src/components/recipes/leftover-ingredients-picker.tsx
+++ b/src/components/recipes/leftover-ingredients-picker.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ROUTES } from "@/app/constants";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PremiumFeatureNotice } from "@/components/premium-feature-notice";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn, titleCase } from "@/lib/utils";
@@ -10,8 +11,7 @@ import { api } from "convex/_generated/api";
 import type { Id } from "convex/_generated/dataModel";
 import { LEFTOVER_INGREDIENTS_MAX } from "convex/lib/constants";
 import { useQuery } from "convex/react";
-import { Loader2, Lock, Sparkles, X } from "lucide-react";
-import Link from "next/link";
+import { Loader2, Sparkles, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 function normalisePhrase(s: string): string {
@@ -126,24 +126,31 @@ export function LeftoverIngredientsPicker({
     totalSelected < LEFTOVER_INGREDIENTS_MAX;
 
   return (
-    <div className="relative space-y-2 rounded-lg border border-border/80 bg-muted/20 p-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <Sparkles className="size-4 shrink-0 text-primary" aria-hidden />
-        <Label className="text-sm font-medium text-foreground">
-          Use up ingredients
-        </Label>
-        <Badge
-          variant="secondary"
-          className="text-[10px] font-semibold uppercase"
-        >
-          Pro
-        </Badge>
-      </div>
-      <p className="text-sm text-muted-foreground">{description}</p>
+    <Card className="relative border-border/80 bg-muted/20">
+      <CardContent className="space-y-2 p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Sparkles className="size-4 shrink-0 text-primary" aria-hidden />
+          <Label className="text-base font-semibold text-foreground">
+            Use up ingredients
+          </Label>
+          <Badge
+            variant="secondary"
+            className="text-[10px] font-semibold uppercase"
+          >
+            Pro
+          </Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">{description}</p>
+        {locked ? (
+          <PremiumFeatureNotice
+            title="Use up ingredients is premium"
+            description="You can preview this feature now. Upgrade on"
+          />
+        ) : null}
 
-      <div
-        className={cn("space-y-2", locked && "pointer-events-none opacity-60")}
-      >
+        <div
+          className={cn("space-y-2", locked && "pointer-events-none opacity-60")}
+        >
         <div className="relative max-w-md">
           <Input
             placeholder={
@@ -289,23 +296,8 @@ export function LeftoverIngredientsPicker({
             ))}
           </div>
         )}
-      </div>
-
-      {locked && (
-        <div className="pointer-events-auto absolute inset-0 flex flex-col items-center justify-center gap-3 rounded-lg bg-background/75 p-4 text-center backdrop-blur-[1px]">
-          <Lock className="size-8 text-muted-foreground" aria-hidden />
-          <p className="text-sm font-medium text-foreground">
-            Premium feature — preview only
-          </p>
-          <p className="max-w-xs text-xs text-muted-foreground">
-            See how “use up ingredients” will work. Subscribe to unlock ranking
-            and meal-plan boosts when we leave beta.
-          </p>
-          <Button size="sm" asChild>
-            <Link href={ROUTES.PRICING}>View plans</Link>
-          </Button>
         </div>
-      )}
-    </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-generation meal-plan controls (meal count, start date, duration) with premium gating and an inline premium notice.
  * Meal-plan detail pages with direct path URLs, a generation-only mode, and improved navigation (Back button).
  * Leftover-ingredients picker refreshed to use inline premium notice and updated card layout.
  * Premium notice UI component and clearer premium-required messages when plan creation is restricted.

* **Documentation**
  * README backlog updated: recipe image generator marked complete; new SEO/organic-growth checklist item added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->