### PR TITLE
Add preference management and quick meals feature

### DIFF
--- a/convex/households.ts
+++ b/convex/households.ts
@@ -13,6 +13,33 @@ import {
   getUserSubscription,
 } from "./users";
 
+function buildPreferenceSummary(
+  prefs:
+    | {
+        allergyIngredientIds?: Id<"ingredients">[];
+        allergyPhrases?: string[];
+        excludedPrimaryProteins?: string[];
+      }
+    | undefined,
+) {
+  if (!prefs) {
+    return {
+      hasAny: false,
+      allergyCount: 0,
+      excludedProteinCount: 0,
+    };
+  }
+  const allergyCount =
+    (prefs.allergyIngredientIds?.length ?? 0) +
+    (prefs.allergyPhrases?.length ?? 0);
+  return {
+    hasAny:
+      allergyCount > 0 || (prefs.excludedPrimaryProteins?.length ?? 0) > 0,
+    allergyCount,
+    excludedProteinCount: prefs.excludedPrimaryProteins?.length ?? 0,
+  };
+}
+
 // ============================================================================
 // HELPER FUNCTIONS
 // ============================================================================
@@ -23,12 +50,12 @@ import {
 export async function isHouseholdOwner(
   ctx: QueryCtx,
   userId: Id<"users">,
-  householdId: Id<"households">
+  householdId: Id<"households">,
 ): Promise<boolean> {
   const membership = await ctx.db
     .query("householdMembers")
     .withIndex("by_user_and_household", (q) =>
-      q.eq("userId", userId).eq("householdId", householdId)
+      q.eq("userId", userId).eq("householdId", householdId),
     )
     .unique();
 
@@ -41,12 +68,12 @@ export async function isHouseholdOwner(
 export async function isHouseholdMember(
   ctx: QueryCtx,
   userId: Id<"users">,
-  householdId: Id<"households">
+  householdId: Id<"households">,
 ): Promise<boolean> {
   const membership = await ctx.db
     .query("householdMembers")
     .withIndex("by_user_and_household", (q) =>
-      q.eq("userId", userId).eq("householdId", householdId)
+      q.eq("userId", userId).eq("householdId", householdId),
     )
     .unique();
 
@@ -70,9 +97,7 @@ export async function resolveDefaultHouseholdIdForSharing(
     .collect();
 
   if (explicitHouseholdId !== undefined) {
-    const ok = memberships.some(
-      (m) => m.householdId === explicitHouseholdId
-    );
+    const ok = memberships.some((m) => m.householdId === explicitHouseholdId);
     if (!ok) {
       throw new ConvexError("You are not a member of that household");
     }
@@ -90,7 +115,7 @@ export async function resolveDefaultHouseholdIdForSharing(
 export async function canAccessRecipe(
   ctx: QueryCtx,
   userId: Id<"users">,
-  recipeId: Id<"recipes">
+  recipeId: Id<"recipes">,
 ): Promise<{ canAccess: boolean; isOwner: boolean }> {
   const recipe = await ctx.db.get(recipeId);
   if (!recipe) {
@@ -119,10 +144,10 @@ export async function canAccessRecipe(
       ctx.db
         .query("householdRecipes")
         .withIndex("by_household_and_recipe", (q) =>
-          q.eq("householdId", householdId).eq("recipeId", recipeId)
+          q.eq("householdId", householdId).eq("recipeId", recipeId),
         )
-        .unique()
-    )
+        .unique(),
+    ),
   );
 
   if (sharedRecipes.some((recipe) => recipe != null)) {
@@ -139,7 +164,7 @@ function generateInvitationToken(): string {
   const array = new Uint8Array(32);
   crypto.getRandomValues(array);
   return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
-    ""
+    "",
   );
 }
 
@@ -150,7 +175,7 @@ async function enrichSharedRecipe(
   ctx: QueryCtx,
   shared: Doc<"householdRecipes">,
   userId: Id<"users">,
-  includeHouseholdId?: boolean
+  includeHouseholdId?: boolean,
 ) {
   const recipe = await ctx.db.get(shared.recipeId);
   if (!recipe) return null;
@@ -234,7 +259,7 @@ export const getUserHouseholds = query({
         const memberCount = await ctx.db
           .query("householdMembers")
           .withIndex("by_household", (q) =>
-            q.eq("householdId", membership.householdId)
+            q.eq("householdId", membership.householdId),
           )
           .collect();
 
@@ -242,7 +267,7 @@ export const getUserHouseholds = query({
         const recipeCount = await ctx.db
           .query("householdRecipes")
           .withIndex("by_household", (q) =>
-            q.eq("householdId", membership.householdId)
+            q.eq("householdId", membership.householdId),
           )
           .collect();
 
@@ -252,7 +277,7 @@ export const getUserHouseholds = query({
           memberCount: memberCount.length,
           recipeCount: recipeCount.length,
         };
-      })
+      }),
     );
 
     return households.filter((h) => h !== null);
@@ -292,10 +317,45 @@ export const getHouseholdMembers = query({
           role: membership.role,
           joinedAt: membership.joinedAt,
         };
-      })
+      }),
     );
 
     return members.filter((m) => m !== null);
+  },
+});
+
+/** Members available as preference contributors when generating a household meal plan. */
+export const getGenerationMembersWithPreferences = query({
+  args: {
+    householdId: v.id("households"),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    const isMember = await isHouseholdMember(ctx, user._id, args.householdId);
+    if (!isMember) {
+      throw new ConvexError("You are not a member of this household");
+    }
+
+    const memberships = await ctx.db
+      .query("householdMembers")
+      .withIndex("by_household", (q) => q.eq("householdId", args.householdId))
+      .collect();
+
+    const members = await Promise.all(
+      memberships.map(async (membership) => {
+        const memberUser = await ctx.db.get(membership.userId);
+        if (!memberUser) return null;
+        return {
+          userId: memberUser._id,
+          name: memberUser.name,
+          ...buildPreferenceSummary(memberUser.preferences),
+        };
+      }),
+    );
+
+    return members.filter(
+      (member): member is NonNullable<typeof member> => !!member,
+    );
   },
 });
 
@@ -374,8 +434,8 @@ export const getHouseholdRecipes = query({
 
     const recipes = await Promise.all(
       sharedRecipes.map((shared) =>
-        enrichSharedRecipe(ctx, shared, user._id, false)
-      )
+        enrichSharedRecipe(ctx, shared, user._id, false),
+      ),
     );
 
     return recipes.filter((r): r is NonNullable<typeof r> => r !== null);
@@ -404,19 +464,19 @@ export const getAllHouseholdRecipes = query({
       const sharedRecipes = await ctx.db
         .query("householdRecipes")
         .withIndex("by_household", (q) =>
-          q.eq("householdId", membership.householdId)
+          q.eq("householdId", membership.householdId),
         )
         .collect();
 
       const recipes = await Promise.all(
         sharedRecipes.map((shared) =>
-          enrichSharedRecipe(ctx, shared, user._id, true)
-        )
+          enrichSharedRecipe(ctx, shared, user._id, true),
+        ),
       );
 
       // Filter out null recipes and recipes owned by the current user
       const validRecipes = recipes.filter(
-        (r): r is NonNullable<typeof r> => r !== null && !r.isOwner
+        (r): r is NonNullable<typeof r> => r !== null && !r.isOwner,
       );
 
       allRecipes.push(...validRecipes);
@@ -456,11 +516,7 @@ export const getHouseholdsByRecipeId = query({
 
       const filtered: typeof householdRecipes = [];
       for (const hr of householdRecipes) {
-        const isMember = await isHouseholdMember(
-          ctx,
-          user._id,
-          hr.householdId
-        );
+        const isMember = await isHouseholdMember(ctx, user._id, hr.householdId);
         if (isMember) {
           filtered.push(hr);
         }
@@ -520,7 +576,7 @@ export const createHousehold = mutation({
       memberships.length >= subscription.maxHouseholds
     ) {
       throw new ConvexError(
-        `You've reached the limit of ${subscription.maxHouseholds} household${subscription.maxHouseholds === 1 ? "" : "s"} on this plan.`
+        `You've reached the limit of ${subscription.maxHouseholds} household${subscription.maxHouseholds === 1 ? "" : "s"} on this plan.`,
       );
     }
 
@@ -560,7 +616,7 @@ export const updateHousehold = mutation({
     const isOwner = await isHouseholdOwner(ctx, user._id, args.householdId);
     if (!isOwner) {
       throw new ConvexError(
-        "Only the household owner can update the household"
+        "Only the household owner can update the household",
       );
     }
 
@@ -589,7 +645,7 @@ export const deleteHousehold = mutation({
     const isOwner = await isHouseholdOwner(ctx, user._id, args.householdId);
     if (!isOwner) {
       throw new ConvexError(
-        "Only the household owner can delete the household"
+        "Only the household owner can delete the household",
       );
     }
 
@@ -668,7 +724,7 @@ export const createInvitationLink = mutation({
       internal.households.deleteInvitationLink,
       {
         invitationId,
-      }
+      },
     );
 
     return { invitationId, token };
@@ -712,7 +768,7 @@ export const acceptInvitationByToken = mutation({
     // Check if already used (consumed) - single-use only
     if (invitation.status === "accepted") {
       throw new ConvexError(
-        "This invitation has already been used. Each invitation link can only be used once."
+        "This invitation has already been used. Each invitation link can only be used once.",
       );
     }
 
@@ -729,7 +785,7 @@ export const acceptInvitationByToken = mutation({
     const existingMembership = await ctx.db
       .query("householdMembers")
       .withIndex("by_user_and_household", (q) =>
-        q.eq("userId", user._id).eq("householdId", invitation.householdId)
+        q.eq("userId", user._id).eq("householdId", invitation.householdId),
       )
       .unique();
 
@@ -809,7 +865,7 @@ export const leaveHousehold = mutation({
     const membership = await ctx.db
       .query("householdMembers")
       .withIndex("by_user_and_household", (q) =>
-        q.eq("userId", user._id).eq("householdId", args.householdId)
+        q.eq("userId", user._id).eq("householdId", args.householdId),
       )
       .unique();
 
@@ -819,7 +875,7 @@ export const leaveHousehold = mutation({
 
     if (membership.role === "owner") {
       throw new ConvexError(
-        "The household owner cannot leave. Delete the household instead."
+        "The household owner cannot leave. Delete the household instead.",
       );
     }
 
@@ -860,7 +916,7 @@ export const shareRecipeToHousehold = mutation({
     const existingShare = await ctx.db
       .query("householdRecipes")
       .withIndex("by_household_and_recipe", (q) =>
-        q.eq("householdId", args.householdId).eq("recipeId", args.recipeId)
+        q.eq("householdId", args.householdId).eq("recipeId", args.recipeId),
       )
       .unique();
 
@@ -894,7 +950,7 @@ export const unshareRecipeFromHousehold = mutation({
     const sharedRecipe = await ctx.db
       .query("householdRecipes")
       .withIndex("by_household_and_recipe", (q) =>
-        q.eq("householdId", args.householdId).eq("recipeId", args.recipeId)
+        q.eq("householdId", args.householdId).eq("recipeId", args.recipeId),
       )
       .unique();
 
@@ -908,7 +964,7 @@ export const unshareRecipeFromHousehold = mutation({
 
     if (!isOwner && !isSharer) {
       throw new ConvexError(
-        "Only the household owner or the person who shared the recipe can unshare it"
+        "Only the household owner or the person who shared the recipe can unshare it",
       );
     }
 

--- a/convex/households.ts
+++ b/convex/households.ts
@@ -7,6 +7,7 @@ import {
   query,
   QueryCtx,
 } from "./_generated/server";
+import { canUseHouseholdPreferences } from "./lib/constants";
 import {
   getCurrentUser,
   getCurrentUserOrThrow,
@@ -335,6 +336,9 @@ export const getGenerationMembersWithPreferences = query({
     if (!isMember) {
       throw new ConvexError("You are not a member of this household");
     }
+    const canSeePreferenceSummary = canUseHouseholdPreferences(
+      user.subscriptionTier,
+    );
 
     const memberships = await ctx.db
       .query("householdMembers")
@@ -345,10 +349,13 @@ export const getGenerationMembersWithPreferences = query({
       memberships.map(async (membership) => {
         const memberUser = await ctx.db.get(membership.userId);
         if (!memberUser) return null;
+        const summary = canSeePreferenceSummary
+          ? buildPreferenceSummary(memberUser.preferences)
+          : { hasAny: false, allergyCount: 0, excludedProteinCount: 0 };
         return {
           userId: memberUser._id,
           name: memberUser.name,
-          ...buildPreferenceSummary(memberUser.preferences),
+          ...summary,
         };
       }),
     );

--- a/convex/lib/constants.ts
+++ b/convex/lib/constants.ts
@@ -153,6 +153,8 @@ export const PRIMARY_PROTEINS = [
   "chicken",
   "beef",
   "pork",
+  "duck",
+  "venison",
   "fish",
   "seafood",
   "vegetarian",
@@ -284,7 +286,9 @@ export type SubscriptionTier = (typeof SUBSCRIPTION_TIERS)[number];
  */
 export const BETA_FREE_INCLUDES_PREMIUM_FEATURES = true;
 
-function hasPremiumFeatureAccess(subscriptionTier: string | undefined): boolean {
+function hasPremiumFeatureAccess(
+  subscriptionTier: string | undefined,
+): boolean {
   const tier = subscriptionTier ?? "free_user";
   if (tier === "pro_user") return true;
   if (tier === "free_user") return BETA_FREE_INCLUDES_PREMIUM_FEATURES;
@@ -293,6 +297,10 @@ function hasPremiumFeatureAccess(subscriptionTier: string | undefined): boolean 
 
 /** Max ingredients a user can select for “use up leftovers” flows. */
 export const LEFTOVER_INGREDIENTS_MAX = 10;
+/** Max allergy ingredients/phrases a user can save in preferences. */
+export const USER_PREFERENCE_ALLERGY_TARGETS_MAX = 30;
+/** Max length for a single custom allergy phrase. */
+export const USER_PREFERENCE_ALLERGY_PHRASE_MAX_LENGTH = 60;
 
 /** Premium feature: search/rank recipes and boost meal-plan generation by leftover ingredients. */
 export function canUseLeftoverIngredients(
@@ -322,12 +330,35 @@ export function canUseAdvancedMealPlanControls(
   return hasPremiumFeatureAccess(subscriptionTier);
 }
 
+/** Premium feature: per-user preferences and household preference-aware generation. */
+export function canUseHouseholdPreferences(
+  subscriptionTier: string | undefined,
+): boolean {
+  return hasPremiumFeatureAccess(subscriptionTier);
+}
+
+/** Premium feature: generation-time quick-meal targeting. */
+export function canUseQuickMealPreferences(
+  subscriptionTier: string | undefined,
+): boolean {
+  return hasPremiumFeatureAccess(subscriptionTier);
+}
+
 export const MEAL_PLAN_ERRORS = {
   PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS: "PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS",
-  PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS: "PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS",
+  PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS:
+    "PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS",
   PREMIUM_REQUIRED_ADVANCED_MEAL_PLAN_CONTROLS:
     "PREMIUM_REQUIRED_ADVANCED_MEAL_PLAN_CONTROLS",
+  PREMIUM_REQUIRED_HOUSEHOLD_PREFERENCES:
+    "PREMIUM_REQUIRED_HOUSEHOLD_PREFERENCES",
+  HOUSEHOLD_PREFERENCES_NO_RECIPES: "HOUSEHOLD_PREFERENCES_NO_ELIGIBLE_RECIPES",
+  PREMIUM_REQUIRED_QUICK_MEALS: "PREMIUM_REQUIRED_QUICK_MEALS",
+  QUICK_MEALS_NO_RECIPES: "QUICK_MEALS_NO_ELIGIBLE_RECIPES",
 } as const;
+
+/** Minimum allowed max-minutes value for quick-meal targeting. */
+export const QUICK_MEALS_MIN_MINUTES = 30;
 
 /** Rate limits for AI recipe image generation (same caps for all entitled tiers during beta). */
 export const RECIPE_AI_HERO_LIMITS = {

--- a/convex/mealPlanGenerator.test.ts
+++ b/convex/mealPlanGenerator.test.ts
@@ -9,8 +9,10 @@ import {
   leftoverWeightMultiplier,
 } from "./lib/leftoverIngredients";
 import {
+  recipePassesPreferenceConstraints,
   weight,
   type BehaviourStatsMap,
+  type GenerationPreferenceConstraints,
   type PoolRecipe,
 } from "./mealPlanGenerator";
 
@@ -111,6 +113,63 @@ function runTests(): boolean {
     const w = weight(open, stats, [locked], undefined, undefined, covered);
     const wFresh = weight(open, stats, []);
     assert.equal(w, wFresh / leftoverWeightMultiplier(1, 1));
+  });
+
+  test("preference constraints block allergen by canonical ingredient id", () => {
+    const constraints: GenerationPreferenceConstraints = {
+      allergyIngredientIds: [iid("peanut")],
+    };
+    const allowed = recipePassesPreferenceConstraints(
+      {
+        ingredients: [{ name: "Garlic", ingredientId: iid("garlic") }],
+      },
+      constraints,
+    );
+    const blocked = recipePassesPreferenceConstraints(
+      {
+        ingredients: [{ name: "Peanut butter", ingredientId: iid("peanut") }],
+      },
+      constraints,
+    );
+    assert.equal(allowed, true);
+    assert.equal(blocked, false);
+  });
+
+  test("preference constraints block allergen by phrase fallback", () => {
+    const constraints: GenerationPreferenceConstraints = {
+      allergyPhrases: ["shellfish"],
+    };
+    const blocked = recipePassesPreferenceConstraints(
+      {
+        ingredients: [{ name: "Mixed shellfish stock" }],
+      },
+      constraints,
+    );
+    assert.equal(blocked, false);
+  });
+
+  test("preference constraints apply protein exclusions", () => {
+    const constraints: GenerationPreferenceConstraints = {
+      excludedPrimaryProteins: ["fish"],
+    };
+    assert.equal(
+      recipePassesPreferenceConstraints(
+        {
+          primaryProtein: "fish",
+        },
+        constraints,
+      ),
+      false,
+    );
+    assert.equal(
+      recipePassesPreferenceConstraints(
+        {
+          primaryProtein: "chicken",
+        },
+        constraints,
+      ),
+      true,
+    );
   });
 
   return failed === 0;

--- a/convex/mealPlanGenerator.ts
+++ b/convex/mealPlanGenerator.ts
@@ -25,10 +25,63 @@ import {
 } from "./lib/leftoverIngredients";
 import type { ActorType } from "./recipeBehaviourStats";
 
+export type GenerationPreferenceConstraints = {
+  allergyIngredientIds?: Id<"ingredients">[];
+  allergyPhrases?: string[];
+  excludedPrimaryProteins?: string[];
+};
+
+function normaliseText(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function recipeContainsAllergen(
+  recipe: {
+    ingredients?: Doc<"recipes">["ingredients"];
+  },
+  constraints: GenerationPreferenceConstraints,
+): boolean {
+  const allergyIdSet = new Set(constraints.allergyIngredientIds ?? []);
+  const allergyPhrases = (constraints.allergyPhrases ?? [])
+    .map(normaliseText)
+    .filter(Boolean);
+  if (allergyIdSet.size === 0 && allergyPhrases.length === 0) return false;
+
+  for (const line of recipe.ingredients ?? []) {
+    if (line.ingredientId && allergyIdSet.has(line.ingredientId)) return true;
+    const lineName = normaliseText(line.name ?? "");
+    if (!lineName) continue;
+    if (allergyPhrases.some((phrase) => lineName.includes(phrase))) return true;
+  }
+  return false;
+}
+
+export function recipePassesPreferenceConstraints(
+  recipe: {
+    primaryProtein?: string | null;
+    prepTime?: number | null;
+    cookTime?: number | null;
+    totalTimeMinutes?: number | null;
+    ingredients?: Doc<"recipes">["ingredients"];
+  },
+  constraints: GenerationPreferenceConstraints | undefined,
+): boolean {
+  if (!constraints) return true;
+  const excludedProteinSet = new Set(constraints.excludedPrimaryProteins ?? []);
+  if (recipe.primaryProtein && excludedProteinSet.has(recipe.primaryProtein)) {
+    return false;
+  }
+  if (recipeContainsAllergen(recipe, constraints)) return false;
+  return true;
+}
+
 /** Minimal recipe shape needed for scoring and constraints (Spec 3 Step 2, 5.2). */
 export type PoolRecipe = {
   _id: Id<"recipes">;
   primaryProtein?: string | null;
+  prepTime?: number | null;
+  cookTime?: number | null;
+  totalTimeMinutes?: number | null;
   complexityTier?: string | null;
   cuisine?: string[] | null;
   editorialBias?: number | null;
@@ -57,6 +110,7 @@ export async function buildPool(
   options?: {
     leftoverTargetIds?: Id<"ingredients">[] | null;
     leftoverTargetPhrases?: string[] | null;
+    preferenceConstraints?: GenerationPreferenceConstraints;
   },
 ): Promise<PoolRecipe[]> {
   const pool: PoolRecipe[] = [];
@@ -81,6 +135,9 @@ export async function buildPool(
     _id: Id<"recipes">;
     category?: string | null;
     primaryProtein?: string | null;
+    prepTime?: number | null;
+    cookTime?: number | null;
+    totalTimeMinutes?: number | null;
     complexityTier?: string | null;
     cuisine?: string[] | null;
     editorialBias?: number | null;
@@ -92,6 +149,8 @@ export async function buildPool(
   }) => {
     if (seenIds.has(r._id)) return;
     if (!recipeIsInMealPlanGeneratorPool(r)) return;
+    if (!recipePassesPreferenceConstraints(r, options?.preferenceConstraints))
+      return;
     seenIds.add(r._id);
     let leftoverMatchKeys: string[] | undefined;
     let leftoverMatchCount: number | undefined;
@@ -107,6 +166,10 @@ export async function buildPool(
     pool.push({
       _id: r._id,
       primaryProtein: r.primaryProtein,
+      prepTime: (r as { prepTime?: number | null }).prepTime,
+      cookTime: (r as { cookTime?: number | null }).cookTime,
+      totalTimeMinutes: (r as { totalTimeMinutes?: number | null })
+        .totalTimeMinutes,
       complexityTier: r.complexityTier,
       cuisine: r.cuisine,
       editorialBias: r.editorialBias,
@@ -283,17 +346,16 @@ export function weight(
     }
   }
 
-  const libraryBoost = recipe.isSystem ? 1 : LIBRARY_MEAL_PLAN_WEIGHT_MULTIPLIER;
+  const libraryBoost = recipe.isSystem
+    ? 1
+    : LIBRARY_MEAL_PLAN_WEIGHT_MULTIPLIER;
   let w = score * bias * libraryBoost;
   if (
     recipe.leftoverTargetCount != null &&
     recipe.leftoverTargetCount > 0 &&
     novelCount > 0
   ) {
-    w *= leftoverWeightMultiplier(
-      novelCount,
-      recipe.leftoverTargetCount,
-    );
+    w *= leftoverWeightMultiplier(novelCount, recipe.leftoverTargetCount);
   }
   return w;
 }
@@ -308,7 +370,7 @@ function seededRandom(seed: string): () => number {
     state = Math.imul(31, state) + seed.charCodeAt(i);
     state = (state << 13) | (state >>> 19);
   }
-  state = (state >>> 0) || 1;
+  state = state >>> 0 || 1;
   return function next() {
     let t = (state += 0x6d2b79f5);
     t = Math.imul(t ^ (t >>> 15), t | 1);
@@ -335,8 +397,9 @@ export function selectRecipes(
   const selected: PoolRecipe[] = [...alreadySelectedLocked];
   const result: Id<"recipes">[] = [];
   const rng = seededRandom(seed);
-  const coveredLeftoverTargetKeys =
-    coveredLeftoverKeysFromRecipes(alreadySelectedLocked);
+  const coveredLeftoverTargetKeys = coveredLeftoverKeysFromRecipes(
+    alreadySelectedLocked,
+  );
 
   const leftoverTargetTotal = sortedPool.find(
     (p) => p.leftoverTargetCount != null && p.leftoverTargetCount > 0,

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -285,10 +285,16 @@ function resolveRecipeTotalTimeMinutes(recipe: {
   totalTimeMinutes?: number | null;
   prepTime?: number | null;
   cookTime?: number | null;
-}): number {
-  return (
-    recipe.totalTimeMinutes ?? (recipe.prepTime ?? 0) + (recipe.cookTime ?? 0)
-  );
+}): number | null {
+  if (
+    recipe.totalTimeMinutes !== undefined &&
+    recipe.totalTimeMinutes !== null
+  ) {
+    return recipe.totalTimeMinutes;
+  }
+  if (recipe.prepTime === undefined || recipe.prepTime === null) return null;
+  if (recipe.cookTime === undefined || recipe.cookTime === null) return null;
+  return recipe.prepTime + recipe.cookTime;
 }
 
 function assertValidEntryPlacement(args: {
@@ -880,10 +886,10 @@ export const generateWeeklyPlan = mutation({
       args.quickMealsCount !== undefined &&
       args.quickMealsMaxMinutes !== undefined
     ) {
-      const quickPool = pool.filter(
-        (recipe) =>
-          resolveRecipeTotalTimeMinutes(recipe) <= args.quickMealsMaxMinutes!,
-      );
+      const quickPool = pool.filter((recipe) => {
+        const totalTime = resolveRecipeTotalTimeMinutes(recipe);
+        return totalTime !== null && totalTime <= args.quickMealsMaxMinutes!;
+      });
       if (quickPool.length < args.quickMealsCount) {
         throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
       }
@@ -910,6 +916,9 @@ export const generateWeeklyPlan = mutation({
         new Set<Id<"recipes">>([...recentlySuggested, ...quickIds]),
         quickPool.filter((recipe) => quickIdSet.has(recipe._id)),
       );
+      if (remainderIds.length !== dayCount - quickIds.length) {
+        throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
+      }
       selectedIds = [...quickIds, ...remainderIds];
     } else {
       selectedIds = selectRecipes(
@@ -1122,6 +1131,19 @@ export const regenerateWeeklyPlan = mutation({
       ...(wantsLeftovers && leftover.phrases
         ? { leftoverIngredientPhrases: leftover.phrases }
         : {}),
+      ...(previousPlan.includedMemberUserIds
+        ? { includedMemberUserIds: previousPlan.includedMemberUserIds }
+        : {}),
+      ...(previousPlan.preferenceFilterSnapshot
+        ? { preferenceFilterSnapshot: previousPlan.preferenceFilterSnapshot }
+        : {}),
+      ...(previousPlan.quickMealsCount !== undefined &&
+      previousPlan.quickMealsMaxMinutes !== undefined
+        ? {
+            quickMealsCount: previousPlan.quickMealsCount,
+            quickMealsMaxMinutes: previousPlan.quickMealsMaxMinutes,
+          }
+        : {}),
     });
 
     const actor = getActorForPlan(previousPlan);
@@ -1155,6 +1177,7 @@ export const regenerateWeeklyPlan = mutation({
         {
           leftoverTargetIds: wantsLeftovers ? leftover.ids : undefined,
           leftoverTargetPhrases: wantsLeftovers ? leftover.phrases : undefined,
+          preferenceConstraints: previousPlan.preferenceFilterSnapshot,
         },
       );
       if (wantsLeftovers) {
@@ -1208,14 +1231,66 @@ export const regenerateWeeklyPlan = mutation({
         }
       }
 
-      const newIds = selectRecipes(
-        pool,
-        toSelect,
-        actorStats,
-        generationSeed,
-        recentlySuggested,
-        lockedPoolRecipes,
-      );
+      let newIds: Id<"recipes">[] = [];
+      if (
+        previousPlan.quickMealsCount !== undefined &&
+        previousPlan.quickMealsMaxMinutes !== undefined
+      ) {
+        const quickTargetCount = Math.min(
+          previousPlan.quickMealsCount,
+          toSelect,
+        );
+        const quickPool = pool.filter((recipe) => {
+          const totalTime = resolveRecipeTotalTimeMinutes(recipe);
+          return (
+            totalTime !== null &&
+            totalTime <= previousPlan.quickMealsMaxMinutes!
+          );
+        });
+        if (quickPool.length < quickTargetCount) {
+          throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
+        }
+        const quickIds = selectRecipes(
+          quickPool,
+          quickTargetCount,
+          actorStats,
+          `${generationSeed}:quick`,
+          recentlySuggested,
+          lockedPoolRecipes,
+        );
+        if (quickIds.length < quickTargetCount) {
+          throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
+        }
+        const quickIdSet = new Set(quickIds);
+        const remainderPool = pool.filter(
+          (recipe) => !quickIdSet.has(recipe._id),
+        );
+        const remainderTarget = toSelect - quickIds.length;
+        const remainderIds = selectRecipes(
+          remainderPool,
+          remainderTarget,
+          actorStats,
+          `${generationSeed}:remainder`,
+          new Set<Id<"recipes">>([...recentlySuggested, ...quickIds]),
+          [
+            ...lockedPoolRecipes,
+            ...quickPool.filter((r) => quickIdSet.has(r._id)),
+          ],
+        );
+        if (remainderIds.length !== remainderTarget) {
+          throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
+        }
+        newIds = [...quickIds, ...remainderIds];
+      } else {
+        newIds = selectRecipes(
+          pool,
+          toSelect,
+          actorStats,
+          generationSeed,
+          recentlySuggested,
+          lockedPoolRecipes,
+        );
+      }
 
       for (let i = 0; i < newIds.length; i++) {
         const recipeId = newIds[i];

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -9,10 +9,14 @@ import {
 import {
   canCreateMultipleMealPlans,
   canUseAdvancedMealPlanControls,
+  canUseHouseholdPreferences,
   canUseLeftoverIngredients,
+  canUseQuickMealPreferences,
   LEFTOVER_INGREDIENTS_MAX,
   MAX_DAYS_IN_MEAL_PLAN,
   MEAL_PLAN_ERRORS,
+  PRIMARY_PROTEINS,
+  QUICK_MEALS_MIN_MINUTES,
   RECENTLY_SUGGESTED_DAYS,
 } from "./lib/constants";
 import {
@@ -70,6 +74,97 @@ function prepareLeftoverInputs(
     phrases: phrases.length ? phrases : undefined,
     totalCount,
     wantsLeftovers: totalCount > 0,
+  };
+}
+
+type UserPreferenceShape = NonNullable<Doc<"users">["preferences"]>;
+
+function normalisePreferencePhrase(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+async function resolveGenerationPreferenceConstraints(args: {
+  ctx: QueryCtx;
+  ownerUserId: Id<"users">;
+  householdId: Id<"households"> | undefined;
+  includedMemberUserIds: Id<"users">[] | undefined;
+  subscriptionTier: string | undefined;
+}): Promise<{
+  includedMemberUserIds: Id<"users">[] | undefined;
+  snapshot:
+    | {
+        allergyIngredientIds: Id<"ingredients">[];
+        allergyPhrases: string[];
+        excludedPrimaryProteins: (typeof PRIMARY_PROTEINS)[number][];
+      }
+    | undefined;
+}> {
+  const wantsPreferenceFiltering =
+    (args.includedMemberUserIds?.length ?? 0) > 0 &&
+    args.householdId !== undefined;
+  if (!wantsPreferenceFiltering) {
+    return { includedMemberUserIds: undefined, snapshot: undefined };
+  }
+  if (!canUseHouseholdPreferences(args.subscriptionTier)) {
+    throw new ConvexError(
+      MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_HOUSEHOLD_PREFERENCES,
+    );
+  }
+
+  const members = await args.ctx.db
+    .query("householdMembers")
+    .withIndex("by_household", (q) => q.eq("householdId", args.householdId!))
+    .collect();
+  const memberSet = new Set(members.map((member) => member.userId));
+  const uniqueSelected = Array.from(new Set(args.includedMemberUserIds ?? []));
+  const validSelected = uniqueSelected.filter((id) => memberSet.has(id));
+  if (!validSelected.includes(args.ownerUserId)) {
+    validSelected.unshift(args.ownerUserId);
+  }
+  if (validSelected.length === 0) {
+    return { includedMemberUserIds: undefined, snapshot: undefined };
+  }
+
+  const selectedUsers = await Promise.all(
+    validSelected.map((userId) => args.ctx.db.get(userId)),
+  );
+
+  const allergyIngredientIds = new Set<Id<"ingredients">>();
+  const allergyPhrases = new Set<string>();
+  const excludedPrimaryProteins = new Set<(typeof PRIMARY_PROTEINS)[number]>();
+
+  for (const user of selectedUsers) {
+    const prefs: UserPreferenceShape | undefined = user?.preferences;
+    if (!prefs) continue;
+    for (const id of prefs.allergyIngredientIds ?? [])
+      allergyIngredientIds.add(id);
+    for (const phrase of prefs.allergyPhrases ?? []) {
+      const normalized = normalisePreferencePhrase(phrase);
+      if (normalized) allergyPhrases.add(normalized);
+    }
+    for (const protein of prefs.excludedPrimaryProteins ?? []) {
+      if ((PRIMARY_PROTEINS as readonly string[]).includes(protein)) {
+        excludedPrimaryProteins.add(
+          protein as (typeof PRIMARY_PROTEINS)[number],
+        );
+      }
+    }
+  }
+
+  const snapshot = {
+    allergyIngredientIds: Array.from(allergyIngredientIds),
+    allergyPhrases: Array.from(allergyPhrases),
+    excludedPrimaryProteins: Array.from(excludedPrimaryProteins),
+  };
+
+  const hasAnyFilters =
+    snapshot.allergyIngredientIds.length > 0 ||
+    snapshot.allergyPhrases.length > 0 ||
+    snapshot.excludedPrimaryProteins.length > 0;
+
+  return {
+    includedMemberUserIds: validSelected,
+    snapshot: hasAnyFilters ? snapshot : undefined,
   };
 }
 
@@ -157,7 +252,9 @@ async function assertCanCreateAnotherPlanForUser(
     .collect();
   const hasExisting = activeOwnedPlans.some((plan) => !plan.replacedByPlanId);
   if (hasExisting) {
-    throw new ConvexError(MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS);
+    throw new ConvexError(
+      MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_MULTIPLE_MEAL_PLANS,
+    );
   }
 }
 
@@ -182,6 +279,16 @@ function effectivePlanStartMs(
 function getPlanDayCount(plan: Doc<"mealPlans">): number {
   const planStart = plan.startDate ?? plan.endDate;
   return Math.max(1, Math.floor((plan.endDate - planStart) / ONE_DAY_MS) + 1);
+}
+
+function resolveRecipeTotalTimeMinutes(recipe: {
+  totalTimeMinutes?: number | null;
+  prepTime?: number | null;
+  cookTime?: number | null;
+}): number {
+  return (
+    recipe.totalTimeMinutes ?? (recipe.prepTime ?? 0) + (recipe.cookTime ?? 0)
+  );
 }
 
 function assertValidEntryPlacement(args: {
@@ -431,7 +538,9 @@ async function buildEntriesWithRecipes(
         if (!recipe) {
           recipeCache.set(entry.recipeId, null);
         } else {
-          const image = recipe.image ? await ctx.storage.getUrl(recipe.image) : null;
+          const image = recipe.image
+            ? await ctx.storage.getUrl(recipe.image)
+            : null;
           const totalTimeMinutes =
             recipe.totalTimeMinutes ??
             (recipe.prepTime ?? 0) + (recipe.cookTime ?? 0);
@@ -678,6 +787,9 @@ export const generateWeeklyPlan = mutation({
     leftoverIngredientPhrases: v.optional(v.array(v.string())),
     startDate: v.optional(v.number()),
     dayCount: v.optional(v.number()),
+    includedMemberUserIds: v.optional(v.array(v.id("users"))),
+    quickMealsCount: v.optional(v.number()),
+    quickMealsMaxMinutes: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUserOrThrow(ctx);
@@ -687,6 +799,31 @@ export const generateWeeklyPlan = mutation({
       dayCount: args.dayCount,
       subscriptionTier: user.subscriptionTier,
     });
+    const wantsQuickMeals = args.quickMealsCount !== undefined;
+    if (wantsQuickMeals && !canUseQuickMealPreferences(user.subscriptionTier)) {
+      throw new ConvexError(MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_QUICK_MEALS);
+    }
+    if (wantsQuickMeals) {
+      if (
+        !Number.isInteger(args.quickMealsCount) ||
+        (args.quickMealsCount ?? 0) < 1
+      ) {
+        throw new ConvexError(
+          "quickMealsCount must be a positive whole number",
+        );
+      }
+      if ((args.quickMealsCount ?? 0) > dayCount) {
+        throw new ConvexError("quickMealsCount cannot exceed dayCount");
+      }
+      if (!Number.isInteger(args.quickMealsMaxMinutes)) {
+        throw new ConvexError("quickMealsMaxMinutes must be a whole number");
+      }
+      if ((args.quickMealsMaxMinutes ?? 0) < QUICK_MEALS_MIN_MINUTES) {
+        throw new ConvexError(
+          `quickMealsMaxMinutes must be at least ${QUICK_MEALS_MIN_MINUTES}`,
+        );
+      }
+    }
     await assertCanCreateAnotherPlanForUser(
       ctx,
       user._id,
@@ -698,6 +835,13 @@ export const generateWeeklyPlan = mutation({
       user._id,
       args.householdId,
     );
+    const preferenceConstraints = await resolveGenerationPreferenceConstraints({
+      ctx,
+      ownerUserId: user._id,
+      householdId: shareHouseholdId,
+      includedMemberUserIds: args.includedMemberUserIds,
+      subscriptionTier: user.subscriptionTier,
+    });
 
     const leftover = prepareLeftoverInputs(
       args.leftoverIngredientIds?.filter(Boolean) as
@@ -707,7 +851,9 @@ export const generateWeeklyPlan = mutation({
     );
     const wantsLeftovers = leftover.wantsLeftovers;
     if (wantsLeftovers && !canUseLeftoverIngredients(user.subscriptionTier)) {
-      throw new ConvexError(MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS);
+      throw new ConvexError(
+        MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS,
+      );
     }
 
     const generationSeed = `gen-${now}-${Math.random().toString(36).slice(2, 11)}`;
@@ -718,6 +864,7 @@ export const generateWeeklyPlan = mutation({
     const pool = await buildPool(ctx, user._id, shareHouseholdId ?? null, {
       leftoverTargetIds: wantsLeftovers ? leftover.ids : undefined,
       leftoverTargetPhrases: wantsLeftovers ? leftover.phrases : undefined,
+      preferenceConstraints: preferenceConstraints.snapshot,
     });
     const recentlySuggested = await getRecentlySuggested(
       ctx,
@@ -727,16 +874,60 @@ export const generateWeeklyPlan = mutation({
     );
     const actorStats = await getBehaviourStatsForActor(ctx, actorType, actorId);
 
-    const selectedIds = selectRecipes(
-      pool,
-      dayCount,
-      actorStats,
-      generationSeed,
-      recentlySuggested,
-      [],
-    );
+    let selectedIds: Id<"recipes">[] = [];
+    if (
+      wantsQuickMeals &&
+      args.quickMealsCount !== undefined &&
+      args.quickMealsMaxMinutes !== undefined
+    ) {
+      const quickPool = pool.filter(
+        (recipe) =>
+          resolveRecipeTotalTimeMinutes(recipe) <= args.quickMealsMaxMinutes!,
+      );
+      if (quickPool.length < args.quickMealsCount) {
+        throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
+      }
+      const quickIds = selectRecipes(
+        quickPool,
+        args.quickMealsCount,
+        actorStats,
+        `${generationSeed}:quick`,
+        recentlySuggested,
+        [],
+      );
+      if (quickIds.length < args.quickMealsCount) {
+        throw new ConvexError(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES);
+      }
+      const quickIdSet = new Set(quickIds);
+      const remainderPool = pool.filter(
+        (recipe) => !quickIdSet.has(recipe._id),
+      );
+      const remainderIds = selectRecipes(
+        remainderPool,
+        dayCount - quickIds.length,
+        actorStats,
+        `${generationSeed}:remainder`,
+        new Set<Id<"recipes">>([...recentlySuggested, ...quickIds]),
+        quickPool.filter((recipe) => quickIdSet.has(recipe._id)),
+      );
+      selectedIds = [...quickIds, ...remainderIds];
+    } else {
+      selectedIds = selectRecipes(
+        pool,
+        dayCount,
+        actorStats,
+        generationSeed,
+        recentlySuggested,
+        [],
+      );
+    }
 
     if (selectedIds.length === 0) {
+      if (preferenceConstraints.snapshot) {
+        throw new ConvexError(
+          MEAL_PLAN_ERRORS.HOUSEHOLD_PREFERENCES_NO_RECIPES,
+        );
+      }
       throw new ConvexError("No recipes available to generate meal plan");
     }
 
@@ -762,6 +953,20 @@ export const generateWeeklyPlan = mutation({
         : {}),
       ...(wantsLeftovers && leftover.phrases
         ? { leftoverIngredientPhrases: leftover.phrases }
+        : {}),
+      ...(preferenceConstraints.includedMemberUserIds
+        ? { includedMemberUserIds: preferenceConstraints.includedMemberUserIds }
+        : {}),
+      ...(preferenceConstraints.snapshot
+        ? { preferenceFilterSnapshot: preferenceConstraints.snapshot }
+        : {}),
+      ...(wantsQuickMeals &&
+      args.quickMealsCount !== undefined &&
+      args.quickMealsMaxMinutes !== undefined
+        ? {
+            quickMealsCount: args.quickMealsCount,
+            quickMealsMaxMinutes: args.quickMealsMaxMinutes,
+          }
         : {}),
     });
 
@@ -865,7 +1070,9 @@ export const regenerateWeeklyPlan = mutation({
     );
     const wantsLeftovers = leftover.wantsLeftovers;
     if (wantsLeftovers && !canUseLeftoverIngredients(user.subscriptionTier)) {
-      throw new ConvexError(MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS);
+      throw new ConvexError(
+        MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_LEFTOVER_INGREDIENTS,
+      );
     }
 
     let leftoverDocs: Doc<"ingredients">[] = [];

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -61,6 +61,13 @@ export default defineSchema({
     subscriptionStatus: v.optional(v.string()), // active, canceled, etc.
     subscriptionId: v.optional(v.string()), // Clerk subscription ID
     lastSubscriptionSync: v.optional(v.number()), // timestamp of last sync
+    preferences: v.optional(
+      v.object({
+        allergyIngredientIds: v.optional(v.array(v.id("ingredients"))),
+        allergyPhrases: v.optional(v.array(v.string())),
+        excludedPrimaryProteins: v.optional(v.array(primaryProteinUnion)),
+      }),
+    ),
   }).index("byExternalId", ["externalId"]),
 
   recipes: defineTable({
@@ -325,6 +332,19 @@ export default defineSchema({
     leftoverIngredientIds: v.optional(v.array(v.id("ingredients"))),
     /** Free-text targets (no catalog row); matched with fuzzy line matching. */
     leftoverIngredientPhrases: v.optional(v.array(v.string())),
+    /** Household members included when generation aggregated profile constraints. */
+    includedMemberUserIds: v.optional(v.array(v.id("users"))),
+    /** Snapshot of generation-time aggregated preference constraints for audit/debug. */
+    preferenceFilterSnapshot: v.optional(
+      v.object({
+        allergyIngredientIds: v.array(v.id("ingredients")),
+        allergyPhrases: v.array(v.string()),
+        excludedPrimaryProteins: v.array(primaryProteinUnion),
+      }),
+    ),
+    /** Optional generation-time target: guarantee this many meals at or under max total minutes. */
+    quickMealsCount: v.optional(v.number()),
+    quickMealsMaxMinutes: v.optional(v.number()),
   })
     .index("by_user", ["userId"])
     .index("by_user_and_endDate", ["userId", "endDate"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -30,6 +30,9 @@ const ingredientFoodGroupUnion = v.union(
 const ingredientFoodSubGroupUnion = v.union(
   ...INGREDIENT_FOOD_SUB_GROUPS.map(v.literal),
 );
+const preferenceAllergyIngredientIdsValidator = v.array(v.id("ingredients"));
+const preferenceAllergyPhrasesValidator = v.array(v.string());
+const preferenceExcludedPrimaryProteinsValidator = v.array(primaryProteinUnion);
 
 export {
   categoriesUnion,
@@ -63,9 +66,13 @@ export default defineSchema({
     lastSubscriptionSync: v.optional(v.number()), // timestamp of last sync
     preferences: v.optional(
       v.object({
-        allergyIngredientIds: v.optional(v.array(v.id("ingredients"))),
-        allergyPhrases: v.optional(v.array(v.string())),
-        excludedPrimaryProteins: v.optional(v.array(primaryProteinUnion)),
+        allergyIngredientIds: v.optional(
+          preferenceAllergyIngredientIdsValidator,
+        ),
+        allergyPhrases: v.optional(preferenceAllergyPhrasesValidator),
+        excludedPrimaryProteins: v.optional(
+          preferenceExcludedPrimaryProteinsValidator,
+        ),
       }),
     ),
   }).index("byExternalId", ["externalId"]),
@@ -337,9 +344,9 @@ export default defineSchema({
     /** Snapshot of generation-time aggregated preference constraints for audit/debug. */
     preferenceFilterSnapshot: v.optional(
       v.object({
-        allergyIngredientIds: v.array(v.id("ingredients")),
-        allergyPhrases: v.array(v.string()),
-        excludedPrimaryProteins: v.array(primaryProteinUnion),
+        allergyIngredientIds: preferenceAllergyIngredientIdsValidator,
+        allergyPhrases: preferenceAllergyPhrasesValidator,
+        excludedPrimaryProteins: preferenceExcludedPrimaryProteinsValidator,
       }),
     ),
     /** Optional generation-time target: guarantee this many meals at or under max total minutes. */

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -5,11 +5,20 @@ import { Doc } from "./_generated/dataModel";
 import {
   internalAction,
   internalMutation,
+  mutation,
   MutationCtx,
   query,
   QueryCtx,
 } from "./_generated/server";
-import { PLANS, SUBSCRIPTION_TIERS } from "./lib/constants";
+import {
+  canUseHouseholdPreferences,
+  MEAL_PLAN_ERRORS,
+  PLANS,
+  PRIMARY_PROTEINS,
+  SUBSCRIPTION_TIERS,
+  USER_PREFERENCE_ALLERGY_PHRASE_MAX_LENGTH,
+  USER_PREFERENCE_ALLERGY_TARGETS_MAX,
+} from "./lib/constants";
 
 export const current = query({
   args: {},
@@ -209,5 +218,85 @@ export const syncUserWithClerk = internalAction({
     } catch (error) {
       console.error(`Error syncing user ${externalId} with Clerk:`, error);
     }
+  },
+});
+
+function normalisePreferencePhrase(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export const getMyPreferences = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    return (
+      user.preferences ?? {
+        allergyIngredientIds: [],
+        allergyPhrases: [],
+        excludedPrimaryProteins: [],
+      }
+    );
+  },
+});
+
+export const updateMyPreferences = mutation({
+  args: {
+    allergyIngredientIds: v.optional(v.array(v.id("ingredients"))),
+    allergyPhrases: v.optional(v.array(v.string())),
+    excludedPrimaryProteins: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    if (!canUseHouseholdPreferences(user.subscriptionTier)) {
+      throw new ConvexError(
+        MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_HOUSEHOLD_PREFERENCES,
+      );
+    }
+
+    const allergyIngredientIds = Array.from(
+      new Set(args.allergyIngredientIds ?? []),
+    );
+    const allergyPhrases = Array.from(
+      new Set(
+        (args.allergyPhrases ?? [])
+          .map(normalisePreferencePhrase)
+          .filter(Boolean)
+          .filter(
+            (phrase) =>
+              phrase.length <= USER_PREFERENCE_ALLERGY_PHRASE_MAX_LENGTH,
+          ),
+      ),
+    );
+
+    if (
+      allergyIngredientIds.length + allergyPhrases.length >
+      USER_PREFERENCE_ALLERGY_TARGETS_MAX
+    ) {
+      throw new ConvexError(
+        `At most ${USER_PREFERENCE_ALLERGY_TARGETS_MAX} allergy targets are allowed`,
+      );
+    }
+
+    const excludedPrimaryProteins = Array.from(
+      new Set(args.excludedPrimaryProteins ?? []),
+    ) as (typeof PRIMARY_PROTEINS)[number][];
+    const invalidProteins = excludedPrimaryProteins.filter(
+      (protein) => !(PRIMARY_PROTEINS as readonly string[]).includes(protein),
+    );
+    if (invalidProteins.length > 0) {
+      throw new ConvexError(
+        `Invalid primary proteins: ${invalidProteins.join(", ")}`,
+      );
+    }
+
+    await ctx.db.patch(user._id, {
+      preferences: {
+        allergyIngredientIds,
+        allergyPhrases,
+        excludedPrimaryProteins,
+      },
+    });
+
+    return { success: true };
   },
 });

--- a/src/app/(app)/_components.tsx/header.tsx
+++ b/src/app/(app)/_components.tsx/header.tsx
@@ -37,6 +37,7 @@ import {
   MessageCircleQuestionMark,
   MessageSquare,
   Moon,
+  Settings2,
   Shield,
   ShoppingCart,
   Sparkles,
@@ -125,6 +126,26 @@ export function Header() {
                           <div className="font-medium">Home</div>
                           <div className="text-sm text-muted-foreground">
                             Dashboard
+                          </div>
+                        </div>
+                      </Link>
+                    </Button>
+                  </li>
+                  <li>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-start h-auto"
+                      asChild
+                    >
+                      <Link
+                        href={ROUTES.PREFERENCES}
+                        onClick={() => setMenuOpen(false)}
+                      >
+                        <Settings2 className="size-4 mr-3" />
+                        <div className="text-left">
+                          <div className="font-medium">Settings</div>
+                          <div className="text-sm text-muted-foreground">
+                            Preferences and account setup
                           </div>
                         </div>
                       </Link>

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -1444,8 +1444,15 @@ export default function MealPlanClient({
                   title="Include member preferences"
                 />
                 <p className="text-sm text-muted-foreground">
-                  Selected members are included by default. Allergies are
-                  treated as hard exclusions.
+                  Tap to exclude members from this plan. For anyone still
+                  included, we won&apos;t suggest recipes that use their listed{" "}
+                  <Link
+                    href={ROUTES.PREFERENCES}
+                    className="text-primary underline"
+                  >
+                    preferences and allergens
+                  </Link>
+                  .
                 </p>
                 {canUseMealPlanLeftovers ? (
                   <MemberPreferenceCards

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -302,7 +302,8 @@ function useMealPlanRoutingState(args: {
 
 type GenerationActionButtonsProps = {
   isGenerating: boolean;
-  disabled: boolean;
+  disabledManual: boolean;
+  disabledGenerate: boolean;
   onManual: () => void;
   onGenerate: () => void;
   showUpgradeHint: boolean;
@@ -342,7 +343,8 @@ function resolveMealPlanEntitlements(args: {
 
 function GenerationActionButtons({
   isGenerating,
-  disabled,
+  disabledManual,
+  disabledGenerate,
   onManual,
   onGenerate,
   showUpgradeHint,
@@ -355,7 +357,7 @@ function GenerationActionButtons({
           variant="outline"
           className="w-full sm:flex-1"
           onClick={onManual}
-          disabled={disabled}
+          disabled={disabledManual}
         >
           {isGenerating ? (
             <Loader2 className="size-5 mr-2 animate-spin" />
@@ -368,7 +370,7 @@ function GenerationActionButtons({
           size="lg"
           className="w-full sm:flex-1"
           onClick={onGenerate}
-          disabled={disabled}
+          disabled={disabledGenerate}
         >
           {isGenerating ? (
             <Loader2 className="size-5 mr-2 animate-spin" />
@@ -459,10 +461,12 @@ function QuickMealsPreferenceCard({
   selectedPresetId,
   onSelectPreset,
   isPremiumEnabled,
+  selectedDayCount,
 }: {
   selectedPresetId: QuickMealsPresetId;
   onSelectPreset: (presetId: QuickMealsPresetId) => void;
   isPremiumEnabled: boolean;
+  selectedDayCount: number;
 }) {
   return (
     <Card className="mb-6 border-border/80 bg-muted/20 max-w-2xl mx-auto">
@@ -509,7 +513,18 @@ function QuickMealsPreferenceCard({
                 className="peer sr-only"
               />
               <div className="font-medium">{preset.title}</div>
-              <div className="mt-1 text-xs">{preset.description}</div>
+              <div className="mt-1 text-xs">
+                {preset.id === "automatic"
+                  ? preset.description
+                  : (() => {
+                      const resolved = resolveQuickMealsPayloadFields(
+                        preset.id,
+                        selectedDayCount,
+                      );
+                      if (!resolved) return preset.description;
+                      return `At least ${resolved.quickMealsCount} meal${resolved.quickMealsCount === 1 ? "" : "s"} under ${resolved.quickMealsMaxMinutes}m`;
+                    })()}
+              </div>
             </label>
           ))}
         </div>
@@ -1451,6 +1466,7 @@ export default function MealPlanClient({
             selectedPresetId={quickMealsPresetId}
             onSelectPreset={setQuickMealsPresetId}
             isPremiumEnabled={canUseMealPlanLeftovers}
+            selectedDayCount={selectedDayCount}
           />
           <div className="max-w-2xl mx-auto mb-6 w-full">
             <LeftoverIngredientsPicker
@@ -1554,9 +1570,69 @@ export default function MealPlanClient({
                   </Select>
                 </div>
               ) : null}
+              {effectiveGenerationHouseholdId &&
+              generationMembers &&
+              generationMembers.length > 0 ? (
+                <Card className="mb-6 border-border/80 bg-muted/20 max-w-2xl mx-auto">
+                  <CardContent className="p-3 space-y-3">
+                    <MealPlanProSectionHeader
+                      icon={
+                        <UserRoundCheck
+                          className="size-4 shrink-0 text-primary"
+                          aria-hidden
+                        />
+                      }
+                      title="Include member preferences"
+                    />
+                    <p className="text-sm text-muted-foreground">
+                      Tap to exclude members from this plan. For anyone still
+                      included, we won&apos;t suggest recipes that use their
+                      listed{" "}
+                      <Link
+                        href={ROUTES.PREFERENCES}
+                        className="text-primary underline"
+                      >
+                        preferences and allergens
+                      </Link>
+                      .
+                    </p>
+                    {canUseMealPlanLeftovers ? (
+                      <MemberPreferenceCards
+                        members={generationMembers}
+                        includedMemberIds={includedMemberIds}
+                        onToggle={(userId) =>
+                          setIncludedMemberIds((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(userId)) next.delete(userId);
+                            else next.add(userId);
+                            return next;
+                          })
+                        }
+                      />
+                    ) : (
+                      <PremiumFeatureNotice
+                        title="Pro feature"
+                        description="Member preference filtering is available on Pro."
+                      />
+                    )}
+                    {canUseMealPlanLeftovers && includedMemberIds.size === 0 ? (
+                      <p className="text-xs text-destructive">
+                        Select at least one member to generate a plan.
+                      </p>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              ) : null}
               <GenerationActionButtons
                 isGenerating={isGenerating}
-                disabled={
+                disabledManual={
+                  isGenerating ||
+                  households === undefined ||
+                  missingRequiredHouseholdSelection ||
+                  blocksAdditionalPlansOnFreeTier ||
+                  !entitlementsReady
+                }
+                disabledGenerate={
                   isGenerating ||
                   households === undefined ||
                   missingRequiredHouseholdSelection ||
@@ -1611,6 +1687,7 @@ export default function MealPlanClient({
             selectedPresetId={quickMealsPresetId}
             onSelectPreset={setQuickMealsPresetId}
             isPremiumEnabled={canUseMealPlanLeftovers}
+            selectedDayCount={selectedDayCount}
           />
           {households && households.length > 1 ? (
             <div className="mb-4 w-full max-w-sm text-left space-y-1.5 mx-auto">
@@ -1652,7 +1729,14 @@ export default function MealPlanClient({
               </p>
               <GenerationActionButtons
                 isGenerating={isGenerating}
-                disabled={
+                disabledManual={
+                  isGenerating ||
+                  households === undefined ||
+                  missingRequiredHouseholdSelection ||
+                  blocksAdditionalPlansOnFreeTier ||
+                  !entitlementsReady
+                }
+                disabledGenerate={
                   isGenerating ||
                   households === undefined ||
                   missingRequiredHouseholdSelection ||

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -1556,6 +1556,8 @@ export default function MealPlanClient({
                   isGenerating ||
                   households === undefined ||
                   missingRequiredHouseholdSelection ||
+                  (effectiveGenerationHouseholdId &&
+                    generationMembers === undefined) ||
                   (canUseMealPlanLeftovers &&
                     (generationMembers?.length ?? 0) > 0 &&
                     includedMemberIds.size === 0) ||
@@ -1627,6 +1629,8 @@ export default function MealPlanClient({
                   isGenerating ||
                   households === undefined ||
                   missingRequiredHouseholdSelection ||
+                  (effectiveGenerationHouseholdId &&
+                    generationMembers === undefined) ||
                   (canUseMealPlanLeftovers &&
                     (generationMembers?.length ?? 0) > 0 &&
                     includedMemberIds.size === 0) ||

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -411,18 +411,22 @@ function MemberPreferenceCards({
       {members.map((member) => {
         const selected = includedMemberIds.has(member.userId);
         return (
-          <button
-            type="button"
+          <label
             key={member.userId}
             className={cn(
-              "rounded-lg border p-3 text-left transition-colors",
+              "block rounded-lg border p-3 text-left transition-colors cursor-pointer",
               selected
                 ? "border-primary bg-primary/10"
                 : "border-border bg-card",
             )}
-            onClick={() => onToggle(member.userId)}
-            aria-label={`Toggle ${member.name} preferences`}
           >
+            <input
+              type="checkbox"
+              className="sr-only"
+              checked={selected}
+              onChange={() => onToggle(member.userId)}
+              aria-label={`Include ${member.name} preferences`}
+            />
             <div className="flex items-center justify-between gap-2">
               <span className="font-medium">{member.name}</span>
               <span
@@ -444,7 +448,7 @@ function MemberPreferenceCards({
                 ? ` · ${member.excludedProteinCount} protein exclusion${member.excludedProteinCount === 1 ? "" : "s"}`
                 : ""}
             </p>
-          </button>
+          </label>
         );
       })}
     </div>
@@ -828,11 +832,11 @@ export default function MealPlanClient({
         includedMemberUserIds?: Id<"users">[];
         quickMealsCount?: number;
         quickMealsMaxMinutes?: number;
-      } = requiresHouseholdSelection
-        ? {
-            householdId: generateWeekHouseholdId as Id<"households">,
-          }
-        : {};
+      } = {};
+      if (effectiveGenerationHouseholdId) {
+        payload.householdId =
+          effectiveGenerationHouseholdId as Id<"households">;
+      }
       payload.startDate = selectedStartDate;
       payload.dayCount = selectedDayCount;
       if (
@@ -1607,6 +1611,28 @@ export default function MealPlanClient({
             onSelectPreset={setQuickMealsPresetId}
             isPremiumEnabled={canUseMealPlanLeftovers}
           />
+          {households && households.length > 1 ? (
+            <div className="mb-4 w-full max-w-sm text-left space-y-1.5 mx-auto">
+              <Label htmlFor="empty-gen-household">Household</Label>
+              <Select
+                value={generateWeekHouseholdId}
+                onValueChange={(v) =>
+                  setGenerateWeekHouseholdId(v as Id<"households">)
+                }
+              >
+                <SelectTrigger id="empty-gen-household">
+                  <SelectValue placeholder="Select household" />
+                </SelectTrigger>
+                <SelectContent>
+                  {households.map((h) => (
+                    <SelectItem key={h._id} value={h._id}>
+                      {h.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
           <Card className="border-2 border-dashed border-muted-foreground/25 bg-card p-8 sm:p-10 text-center max-w-xl mx-auto">
             <CardContent className="p-0 flex flex-col items-center">
               <div className="size-16 rounded-full border-2 border-primary/30 bg-primary/10 flex items-center justify-center mb-6">

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -1560,7 +1560,8 @@ export default function MealPlanClient({
                   isGenerating ||
                   households === undefined ||
                   missingRequiredHouseholdSelection ||
-                  (effectiveGenerationHouseholdId &&
+                  (canUseMealPlanLeftovers &&
+                    effectiveGenerationHouseholdId &&
                     generationMembers === undefined) ||
                   (canUseMealPlanLeftovers &&
                     (generationMembers?.length ?? 0) > 0 &&
@@ -1655,7 +1656,8 @@ export default function MealPlanClient({
                   isGenerating ||
                   households === undefined ||
                   missingRequiredHouseholdSelection ||
-                  (effectiveGenerationHouseholdId &&
+                  (canUseMealPlanLeftovers &&
+                    effectiveGenerationHouseholdId &&
                     generationMembers === undefined) ||
                   (canUseMealPlanLeftovers &&
                     (generationMembers?.length ?? 0) > 0 &&

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -50,6 +50,7 @@ import {
   BETA_FREE_INCLUDES_PREMIUM_FEATURES,
   MAX_DAYS_IN_MEAL_PLAN,
   MEAL_PLAN_ERRORS,
+  QUICK_MEALS_MIN_MINUTES,
 } from "convex/lib/constants";
 import { useMutation, useQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
@@ -58,6 +59,7 @@ import {
   ArrowRight,
   CalendarPlus,
   CheckCircle2,
+  Clock3,
   Home,
   Loader2,
   MoreVertical,
@@ -66,10 +68,12 @@ import {
   Sparkles,
   Trash2,
   UserMinus,
+  UserRoundCheck,
   Users,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EmptySlot } from "./empty-slot";
@@ -108,6 +112,18 @@ function mealPlanErrorMessage(e: unknown): string {
   ) {
     return "Custom start dates and day lengths are premium controls.";
   }
+  if (msg.includes(MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_HOUSEHOLD_PREFERENCES)) {
+    return "Household preference filtering is a premium feature.";
+  }
+  if (msg.includes(MEAL_PLAN_ERRORS.HOUSEHOLD_PREFERENCES_NO_RECIPES)) {
+    return "No recipes match the selected member preferences. Try toggling fewer members or loosening restrictions.";
+  }
+  if (msg.includes(MEAL_PLAN_ERRORS.PREMIUM_REQUIRED_QUICK_MEALS)) {
+    return "Quick meal targeting is a premium feature.";
+  }
+  if (msg.includes(MEAL_PLAN_ERRORS.QUICK_MEALS_NO_RECIPES)) {
+    return "Not enough recipes match that quick-meals preset. Try Automatic or a lighter preset.";
+  }
   return msg;
 }
 const MEAL_PLAN_EMPTY_VIEWED_SESSION_KEY =
@@ -138,6 +154,81 @@ type MealPlanClientProps = {
 type MealPlanSummary = NonNullable<
   FunctionReturnType<typeof api.mealPlans.getActiveMealPlanSummaries>
 >[number];
+
+type QuickMealsPresetId = "automatic" | "light" | "balanced" | "fast_focused";
+
+const QUICK_MEAL_PRESETS: Array<{
+  id: QuickMealsPresetId;
+  title: string;
+  description: string;
+  count?: number;
+  maxMinutes?: number;
+}> = [
+  {
+    id: "automatic",
+    title: "Automatic",
+    description: "Balanced speed for the week",
+  },
+  {
+    id: "light",
+    title: "Light",
+    description: "At least 2 meals under 45m",
+    count: 2,
+    maxMinutes: 45,
+  },
+  {
+    id: "balanced",
+    title: "Balanced",
+    description: "At least 3 meals under 40m",
+    count: 3,
+    maxMinutes: 40,
+  },
+  {
+    id: "fast_focused",
+    title: "Fast-focused",
+    description: "At least 4 meals under 35m",
+    count: 4,
+    maxMinutes: 35,
+  },
+];
+
+/** Shared header row for premium meal-plan generator sections (icon + title + Pro badge). */
+function MealPlanProSectionHeader({
+  icon,
+  title,
+}: {
+  icon: ReactNode;
+  title: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {icon}
+      <h2 className="text-base font-semibold text-foreground">{title}</h2>
+      <Badge
+        variant="secondary"
+        className="text-[10px] font-semibold uppercase"
+      >
+        Pro
+      </Badge>
+    </div>
+  );
+}
+
+/** Maps quick-meals preset to mutation fields; clamps count to plan length. */
+function resolveQuickMealsPayloadFields(
+  presetId: QuickMealsPresetId,
+  selectedDayCount: number,
+): { quickMealsCount: number; quickMealsMaxMinutes: number } | null {
+  if (presetId === "automatic") return null;
+  const preset = QUICK_MEAL_PRESETS.find((p) => p.id === presetId);
+  const count = preset?.count;
+  const maxMinutes = preset?.maxMinutes;
+  if (count == null || maxMinutes == null) return null;
+  return {
+    quickMealsCount: Math.min(count, selectedDayCount),
+    quickMealsMaxMinutes: maxMinutes,
+  };
+}
 
 function useMealPlanRoutingState(args: {
   generationOnly: boolean;
@@ -175,7 +266,10 @@ function useMealPlanRoutingState(args: {
     if (args.generationOnly) return;
     if (args.planId) {
       if (resolvedPlanId && typeof window !== "undefined") {
-        sessionStorage.setItem(MEAL_PLAN_LAST_VIEWED_STORAGE_KEY, resolvedPlanId);
+        sessionStorage.setItem(
+          MEAL_PLAN_LAST_VIEWED_STORAGE_KEY,
+          resolvedPlanId,
+        );
       }
       return;
     }
@@ -186,7 +280,9 @@ function useMealPlanRoutingState(args: {
     }
 
     if (resolvedPlanId && args.planParam !== resolvedPlanId) {
-      args.router.replace(ROUTES.mealPlanWithId(resolvedPlanId), { scroll: false });
+      args.router.replace(ROUTES.mealPlanWithId(resolvedPlanId), {
+        scroll: false,
+      });
     }
 
     if (resolvedPlanId && typeof window !== "undefined") {
@@ -221,7 +317,8 @@ function resolveMealPlanEntitlements(args: {
     subscriptionTier === "pro_user" ||
     (subscriptionTier === "free_user" && BETA_FREE_INCLUDES_PREMIUM_FEATURES);
   const entitlementsReady =
-    args.currentUser !== undefined && args.ownedPlanCountForCreation !== undefined;
+    args.currentUser !== undefined &&
+    args.ownedPlanCountForCreation !== undefined;
   const canUseMealPlanLeftovers =
     entitlementsReady && args.currentUser != null && hasPremiumMealPlanAccess;
   const hasActivePlan =
@@ -267,7 +364,12 @@ function GenerationActionButtons({
           )}
           Manual plan
         </Button>
-        <Button size="lg" className="w-full sm:flex-1" onClick={onGenerate} disabled={disabled}>
+        <Button
+          size="lg"
+          className="w-full sm:flex-1"
+          onClick={onGenerate}
+          disabled={disabled}
+        >
           {isGenerating ? (
             <Loader2 className="size-5 mr-2 animate-spin" />
           ) : (
@@ -288,6 +390,127 @@ function GenerationActionButtons({
         </p>
       ) : null}
     </>
+  );
+}
+
+type GenerationMember = NonNullable<
+  FunctionReturnType<typeof api.households.getGenerationMembersWithPreferences>
+>[number];
+
+function MemberPreferenceCards({
+  members,
+  includedMemberIds,
+  onToggle,
+}: {
+  members: GenerationMember[];
+  includedMemberIds: Set<Id<"users">>;
+  onToggle: (userId: Id<"users">) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      {members.map((member) => {
+        const selected = includedMemberIds.has(member.userId);
+        return (
+          <button
+            type="button"
+            key={member.userId}
+            className={cn(
+              "rounded-lg border p-3 text-left transition-colors",
+              selected
+                ? "border-primary bg-primary/10"
+                : "border-border bg-card",
+            )}
+            onClick={() => onToggle(member.userId)}
+            aria-label={`Toggle ${member.name} preferences`}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium">{member.name}</span>
+              <span
+                className={cn(
+                  "inline-flex size-4 items-center justify-center rounded border text-[10px]",
+                  selected
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-muted-foreground/40 text-transparent",
+                )}
+              >
+                ✓
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {member.allergyCount > 0
+                ? `${member.allergyCount} allergy rule${member.allergyCount === 1 ? "" : "s"}`
+                : "No allergy rules"}
+              {member.excludedProteinCount > 0
+                ? ` · ${member.excludedProteinCount} protein exclusion${member.excludedProteinCount === 1 ? "" : "s"}`
+                : ""}
+            </p>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function QuickMealsPreferenceCard({
+  selectedPresetId,
+  onSelectPreset,
+  isPremiumEnabled,
+}: {
+  selectedPresetId: QuickMealsPresetId;
+  onSelectPreset: (presetId: QuickMealsPresetId) => void;
+  isPremiumEnabled: boolean;
+}) {
+  return (
+    <Card className="mb-6 border-border/80 bg-muted/20 max-w-2xl mx-auto">
+      <CardContent className="p-3 space-y-3">
+        <MealPlanProSectionHeader
+          icon={<Clock3 className="size-4 shrink-0 text-primary" aria-hidden />}
+          title="Quick meals"
+        />
+        <p className="text-sm text-muted-foreground">
+          Pick a pace for faster meals this week. Presets guarantee a minimum;
+          the rest of the week is filled as usual.
+        </p>
+        {!isPremiumEnabled ? (
+          <PremiumFeatureNotice
+            title="Pro feature"
+            description="Quick meal targeting is a Pro feature."
+          />
+        ) : null}
+        <div
+          role="radiogroup"
+          aria-label="Quick meal preference presets"
+          className={cn(
+            "grid grid-cols-2 gap-2 sm:grid-cols-3",
+            !isPremiumEnabled && "pointer-events-none opacity-60",
+          )}
+        >
+          {QUICK_MEAL_PRESETS.map((preset) => (
+            <label
+              key={preset.id}
+              className={cn(
+                "rounded-lg border px-3 py-3 text-left text-sm transition-colors cursor-pointer focus-within:ring-2 focus-within:ring-primary/50 focus-within:ring-offset-2",
+                selectedPresetId === preset.id
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border bg-card text-muted-foreground",
+              )}
+            >
+              <input
+                type="radio"
+                name="quick-meals-preset"
+                value={preset.id}
+                checked={selectedPresetId === preset.id}
+                onChange={() => onSelectPreset(preset.id)}
+                disabled={!isPremiumEnabled}
+                className="peer sr-only"
+              />
+              <div className="font-medium">{preset.title}</div>
+              <div className="mt-1 text-xs">{preset.description}</div>
+            </label>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -400,6 +623,9 @@ export default function MealPlanClient({
   >("");
 
   const [isFinalising, setIsFinalising] = useState(false);
+  const [includedMemberIds, setIncludedMemberIds] = useState<Set<Id<"users">>>(
+    new Set(),
+  );
   const [pickerState, setPickerState] = useState<{
     mode: "add" | "replace";
     entry?: CurrentPlan["entries"][number];
@@ -424,6 +650,8 @@ export default function MealPlanClient({
   const [customDayCount, setCustomDayCount] = useState(
     String(MAX_DAYS_IN_MEAL_PLAN),
   );
+  const [quickMealsPresetId, setQuickMealsPresetId] =
+    useState<QuickMealsPresetId>("automatic");
   const [startDateOption, setStartDateOption] = useState<
     "today" | "tomorrow" | "following" | "custom"
   >("today");
@@ -442,6 +670,17 @@ export default function MealPlanClient({
   const requiresHouseholdSelection = (households?.length ?? 0) > 1;
   const missingRequiredHouseholdSelection =
     requiresHouseholdSelection && generateWeekHouseholdId === "";
+  const effectiveGenerationHouseholdId = requiresHouseholdSelection
+    ? generateWeekHouseholdId || undefined
+    : households?.length === 1
+      ? households[0]?._id
+      : undefined;
+  const generationMembers = useQuery(
+    api.households.getGenerationMembersWithPreferences,
+    effectiveGenerationHouseholdId
+      ? { householdId: effectiveGenerationHouseholdId as Id<"households"> }
+      : "skip",
+  );
 
   const selectedStartDate = useMemo(() => {
     const utcStartForLocalDate = (offsetDays: number): number => {
@@ -478,6 +717,13 @@ export default function MealPlanClient({
       day: "numeric",
     });
   }, [localDayStartMs]);
+
+  useEffect(() => {
+    if (!generationMembers) return;
+    setIncludedMemberIds(
+      new Set(generationMembers.map((member) => member.userId)),
+    );
+  }, [generationMembers]);
 
   useEffect(() => {
     if (currentUser === undefined) return;
@@ -529,6 +775,15 @@ export default function MealPlanClient({
       toast.info("Select a household before generating your plan.");
       return;
     }
+    if (
+      canUseMealPlanLeftovers &&
+      generationMembers &&
+      generationMembers.length > 0 &&
+      includedMemberIds.size === 0
+    ) {
+      toast.info("Select at least one household member.");
+      return;
+    }
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_GENERATE_WEEK_CLICKED, {
       surface: "meal_plan",
     });
@@ -540,6 +795,9 @@ export default function MealPlanClient({
         leftoverIngredientPhrases?: string[];
         startDate?: number;
         dayCount?: number;
+        includedMemberUserIds?: Id<"users">[];
+        quickMealsCount?: number;
+        quickMealsMaxMinutes?: number;
       } = requiresHouseholdSelection
         ? {
             householdId: generateWeekHouseholdId as Id<"households">,
@@ -556,6 +814,30 @@ export default function MealPlanClient({
         }
         if (mealPlanLeftoverPhrases.length > 0) {
           payload.leftoverIngredientPhrases = mealPlanLeftoverPhrases;
+        }
+      }
+      if (
+        canUseMealPlanLeftovers &&
+        generationMembers &&
+        generationMembers.length > 0
+      ) {
+        payload.includedMemberUserIds = Array.from(includedMemberIds);
+      }
+      if (canUseMealPlanLeftovers) {
+        const quickFields = resolveQuickMealsPayloadFields(
+          quickMealsPresetId,
+          selectedDayCount,
+        );
+        if (quickFields) {
+          if (quickFields.quickMealsMaxMinutes < QUICK_MEALS_MIN_MINUTES) {
+            toast.error(
+              `Quick meals max minutes must be at least ${QUICK_MEALS_MIN_MINUTES}.`,
+            );
+            setIsGenerating(false);
+            return;
+          }
+          payload.quickMealsCount = quickFields.quickMealsCount;
+          payload.quickMealsMaxMinutes = quickFields.quickMealsMaxMinutes;
         }
       }
       const result = await generateWeeklyPlan(payload);
@@ -603,11 +885,14 @@ export default function MealPlanClient({
     households,
     mealPlanLeftoverIds,
     mealPlanLeftoverPhrases,
+    generationMembers,
+    includedMemberIds,
     router,
     selectedDayCount,
     selectedStartDate,
     blocksAdditionalPlansOnFreeTier,
     requiresHouseholdSelection,
+    quickMealsPresetId,
   ]);
 
   const handleBlankWeek = useCallback(async () => {
@@ -1003,23 +1288,17 @@ export default function MealPlanClient({
               </CardContent>
             </Card>
           ) : null}
-          <Card className="mb-6 border-border/80 bg-muted/20">
+          <Card className="mb-6 border-border/80 bg-muted/20 max-w-2xl mx-auto">
             <CardContent className="p-3 space-y-3">
-              <div className="flex flex-wrap items-center gap-2">
-                <SlidersHorizontal
-                  className="size-4 shrink-0 text-primary"
-                  aria-hidden
-                />
-                <h2 className="text-base font-semibold text-foreground">
-                  Meal plan controls
-                </h2>
-                <Badge
-                  variant="secondary"
-                  className="text-[10px] font-semibold uppercase"
-                >
-                  Pro
-                </Badge>
-              </div>
+              <MealPlanProSectionHeader
+                icon={
+                  <SlidersHorizontal
+                    className="size-4 shrink-0 text-primary"
+                    aria-hidden
+                  />
+                }
+                title="Meal plan controls"
+              />
               {controlsLocked ? (
                 <PremiumFeatureNotice
                   title="Pro feature"
@@ -1133,6 +1412,11 @@ export default function MealPlanClient({
               </div>
             </CardContent>
           </Card>
+          <QuickMealsPreferenceCard
+            selectedPresetId={quickMealsPresetId}
+            onSelectPreset={setQuickMealsPresetId}
+            isPremiumEnabled={canUseMealPlanLeftovers}
+          />
           <div className="max-w-2xl mx-auto mb-6 w-full">
             <LeftoverIngredientsPicker
               selectedIds={mealPlanLeftoverIds}
@@ -1145,6 +1429,51 @@ export default function MealPlanClient({
               description="Optional: prioritise recipes that use ingredients you want to finish this week."
             />
           </div>
+          {effectiveGenerationHouseholdId &&
+          generationMembers &&
+          generationMembers.length > 0 ? (
+            <Card className="mb-6 border-border/80 bg-muted/20 max-w-2xl mx-auto">
+              <CardContent className="p-3 space-y-3">
+                <MealPlanProSectionHeader
+                  icon={
+                    <UserRoundCheck
+                      className="size-4 shrink-0 text-primary"
+                      aria-hidden
+                    />
+                  }
+                  title="Include member preferences"
+                />
+                <p className="text-sm text-muted-foreground">
+                  Selected members are included by default. Allergies are
+                  treated as hard exclusions.
+                </p>
+                {canUseMealPlanLeftovers ? (
+                  <MemberPreferenceCards
+                    members={generationMembers}
+                    includedMemberIds={includedMemberIds}
+                    onToggle={(userId) =>
+                      setIncludedMemberIds((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(userId)) next.delete(userId);
+                        else next.add(userId);
+                        return next;
+                      })
+                    }
+                  />
+                ) : (
+                  <PremiumFeatureNotice
+                    title="Pro feature"
+                    description="Member preference filtering is available on Pro."
+                  />
+                )}
+                {canUseMealPlanLeftovers && includedMemberIds.size === 0 ? (
+                  <p className="text-xs text-destructive">
+                    Select at least one member to generate a plan.
+                  </p>
+                ) : null}
+              </CardContent>
+            </Card>
+          ) : null}
           <Card className="border-2 border-dashed border-muted-foreground/25 bg-card p-8 sm:p-10 text-center max-w-xl mx-auto">
             <CardContent className="p-0 flex flex-col items-center">
               <div className="size-16 rounded-full border-2 border-primary/30 bg-primary/10 flex items-center justify-center mb-6">
@@ -1188,7 +1517,10 @@ export default function MealPlanClient({
                 disabled={
                   isGenerating ||
                   households === undefined ||
-                    missingRequiredHouseholdSelection ||
+                  missingRequiredHouseholdSelection ||
+                  (canUseMealPlanLeftovers &&
+                    (generationMembers?.length ?? 0) > 0 &&
+                    includedMemberIds.size === 0) ||
                   blocksAdditionalPlansOnFreeTier ||
                   !entitlementsReady
                 }
@@ -1230,6 +1562,11 @@ export default function MealPlanClient({
               description="Optional: prioritise recipes that use ingredients you want to finish this week."
             />
           </div>
+          <QuickMealsPreferenceCard
+            selectedPresetId={quickMealsPresetId}
+            onSelectPreset={setQuickMealsPresetId}
+            isPremiumEnabled={canUseMealPlanLeftovers}
+          />
           <Card className="border-2 border-dashed border-muted-foreground/25 bg-card p-8 sm:p-10 text-center max-w-xl mx-auto">
             <CardContent className="p-0 flex flex-col items-center">
               <div className="size-16 rounded-full border-2 border-primary/30 bg-primary/10 flex items-center justify-center mb-6">
@@ -1251,7 +1588,10 @@ export default function MealPlanClient({
                 disabled={
                   isGenerating ||
                   households === undefined ||
-                    missingRequiredHouseholdSelection ||
+                  missingRequiredHouseholdSelection ||
+                  (canUseMealPlanLeftovers &&
+                    (generationMembers?.length ?? 0) > 0 &&
+                    includedMemberIds.size === 0) ||
                   blocksAdditionalPlansOnFreeTier ||
                   !entitlementsReady
                 }

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -626,6 +626,8 @@ export default function MealPlanClient({
   const [includedMemberIds, setIncludedMemberIds] = useState<Set<Id<"users">>>(
     new Set(),
   );
+  const memberSeedHouseholdRef = useRef<Id<"households"> | null>(null);
+  const lastGenerationMemberIdsRef = useRef<Set<Id<"users">>>(new Set());
   const [pickerState, setPickerState] = useState<{
     mode: "add" | "replace";
     entry?: CurrentPlan["entries"][number];
@@ -719,11 +721,31 @@ export default function MealPlanClient({
   }, [localDayStartMs]);
 
   useEffect(() => {
-    if (!generationMembers) return;
-    setIncludedMemberIds(
-      new Set(generationMembers.map((member) => member.userId)),
+    if (!effectiveGenerationHouseholdId || !generationMembers) return;
+    const currentMemberIds = new Set(
+      generationMembers.map((member) => member.userId),
     );
-  }, [generationMembers]);
+    setIncludedMemberIds((prev) => {
+      if (memberSeedHouseholdRef.current !== effectiveGenerationHouseholdId) {
+        memberSeedHouseholdRef.current = effectiveGenerationHouseholdId;
+        lastGenerationMemberIdsRef.current = currentMemberIds;
+        return new Set(currentMemberIds);
+      }
+      const next = new Set(prev);
+      for (const id of currentMemberIds) {
+        if (!lastGenerationMemberIdsRef.current.has(id)) {
+          next.add(id);
+        }
+      }
+      for (const id of lastGenerationMemberIdsRef.current) {
+        if (!currentMemberIds.has(id)) {
+          next.delete(id);
+        }
+      }
+      lastGenerationMemberIdsRef.current = currentMemberIds;
+      return next;
+    });
+  }, [effectiveGenerationHouseholdId, generationMembers]);
 
   useEffect(() => {
     if (currentUser === undefined) return;
@@ -773,6 +795,14 @@ export default function MealPlanClient({
     }
     if (requiresHouseholdSelection && generateWeekHouseholdId === "") {
       toast.info("Select a household before generating your plan.");
+      return;
+    }
+    if (
+      effectiveGenerationHouseholdId &&
+      canUseMealPlanLeftovers &&
+      generationMembers === undefined
+    ) {
+      toast.info("Loading household members, please wait.");
       return;
     }
     if (
@@ -887,6 +917,7 @@ export default function MealPlanClient({
     mealPlanLeftoverPhrases,
     generationMembers,
     includedMemberIds,
+    effectiveGenerationHouseholdId,
     router,
     selectedDayCount,
     selectedStartDate,

--- a/src/app/(app)/dashboard/preferences/page.tsx
+++ b/src/app/(app)/dashboard/preferences/page.tsx
@@ -12,6 +12,8 @@ import type { Id } from "convex/_generated/dataModel";
 import {
   BETA_FREE_INCLUDES_PREMIUM_FEATURES,
   PRIMARY_PROTEINS,
+  USER_PREFERENCE_ALLERGY_PHRASE_MAX_LENGTH,
+  USER_PREFERENCE_ALLERGY_TARGETS_MAX,
 } from "convex/lib/constants";
 import { useMutation, useQuery } from "convex/react";
 import {
@@ -102,9 +104,13 @@ export default function PreferencesPage() {
     });
   };
 
+  const allergyTargetCount = allergyIngredientIds.length + allergyPhrases.length;
+
   const addAllergyPhrase = () => {
     const phrase = normalisePhrase(searchQuery);
     if (!phrase) return;
+    if (phrase.length > USER_PREFERENCE_ALLERGY_PHRASE_MAX_LENGTH) return;
+    if (allergyTargetCount >= USER_PREFERENCE_ALLERGY_TARGETS_MAX) return;
     if (allergyPhrases.includes(phrase)) return;
     setAllergyPhrases((prev) => [...prev, phrase]);
     setSearchQuery("");
@@ -114,10 +120,13 @@ export default function PreferencesPage() {
   const canAddCustomPhrase = useMemo(() => {
     const phrase = normalisePhrase(searchQuery);
     if (!phrase) return false;
+    if (phrase.length > USER_PREFERENCE_ALLERGY_PHRASE_MAX_LENGTH) return false;
+    if (allergyTargetCount >= USER_PREFERENCE_ALLERGY_TARGETS_MAX) return false;
     return !allergyPhrases.includes(phrase);
-  }, [allergyPhrases, searchQuery]);
+  }, [allergyPhrases, searchQuery, allergyTargetCount]);
 
   const addAllergyIngredient = (ingredientId: Id<"ingredients">) => {
+    if (allergyTargetCount >= USER_PREFERENCE_ALLERGY_TARGETS_MAX) return;
     if (allergyIngredientIds.includes(ingredientId)) return;
     setAllergyIngredientIds((prev) => [...prev, ingredientId]);
     setSearchQuery("");
@@ -230,6 +239,7 @@ export default function PreferencesPage() {
                 <Label htmlFor="allergy-search">Search allergy items</Label>
                 <Input
                   id="allergy-search"
+                  disabled={!canUsePremiumFeatures}
                   value={searchQuery}
                   onChange={(event) => setSearchQuery(event.target.value)}
                   onKeyDown={(event) => {
@@ -248,6 +258,7 @@ export default function PreferencesPage() {
                     {canAddCustomPhrase ? (
                       <button
                         type="button"
+                        disabled={!canUsePremiumFeatures}
                         className="w-full border-b px-3 py-2 text-left text-sm font-medium text-primary hover:bg-accent"
                         onClick={addAllergyPhrase}
                       >
@@ -258,6 +269,7 @@ export default function PreferencesPage() {
                       <button
                         key={row._id}
                         type="button"
+                        disabled={!canUsePremiumFeatures}
                         className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
                         onClick={() => addAllergyIngredient(row._id)}
                       >
@@ -274,6 +286,7 @@ export default function PreferencesPage() {
                       type="button"
                       variant="secondary"
                       size="sm"
+                      disabled={!canUsePremiumFeatures}
                       onClick={addAllergyPhrase}
                     >
                       Add “{searchQuery.trim()}” as allergy
@@ -293,7 +306,7 @@ export default function PreferencesPage() {
                           prev.filter((x) => x !== id),
                         )
                       }
-                      aria-label="Remove ingredient"
+                      aria-label={`Remove ${ingredientLabels.get(id) ?? "ingredient"}`}
                     >
                       <X className="size-3" />
                     </button>
@@ -313,7 +326,7 @@ export default function PreferencesPage() {
                           prev.filter((x) => x !== phrase),
                         )
                       }
-                      aria-label="Remove phrase"
+                      aria-label={`Remove ${phrase}`}
                     >
                       <X className="size-3" />
                     </button>
@@ -352,6 +365,7 @@ export default function PreferencesPage() {
                     <button
                       key={protein}
                       type="button"
+                      disabled={!canUsePremiumFeatures}
                       className={cn(
                         "rounded-full border px-3 py-1.5 text-sm transition-colors",
                         active

--- a/src/app/(app)/dashboard/preferences/page.tsx
+++ b/src/app/(app)/dashboard/preferences/page.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { PremiumFeatureNotice } from "@/components/premium-feature-notice";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { api } from "convex/_generated/api";
+import type { Id } from "convex/_generated/dataModel";
+import {
+  BETA_FREE_INCLUDES_PREMIUM_FEATURES,
+  PRIMARY_PROTEINS,
+} from "convex/lib/constants";
+import { useMutation, useQuery } from "convex/react";
+import {
+  AlertTriangle,
+  FishOff,
+  Loader2,
+  ShieldAlert,
+  UserCog,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+function normalisePhrase(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+const proteinOptions = PRIMARY_PROTEINS.filter(
+  (option) => option !== "other" && option !== "none",
+);
+
+export default function PreferencesPage() {
+  const currentUser = useQuery(api.users.current);
+  const preferences = useQuery(api.users.getMyPreferences);
+  const savePreferences = useMutation(api.users.updateMyPreferences);
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [allergyIngredientIds, setAllergyIngredientIds] = useState<
+    Id<"ingredients">[]
+  >([]);
+  const [allergyPhrases, setAllergyPhrases] = useState<string[]>([]);
+  const [excludedPrimaryProteins, setExcludedPrimaryProteins] = useState<
+    string[]
+  >([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const canUsePremiumFeatures = useMemo(() => {
+    const tier = currentUser?.subscriptionTier ?? "free_user";
+    if (tier === "pro_user") return true;
+    if (tier === "free_user") return BETA_FREE_INCLUDES_PREMIUM_FEATURES;
+    return false;
+  }, [currentUser?.subscriptionTier]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 250);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (!preferences) return;
+    setAllergyIngredientIds(preferences.allergyIngredientIds ?? []);
+    setAllergyPhrases(preferences.allergyPhrases ?? []);
+    setExcludedPrimaryProteins(preferences.excludedPrimaryProteins ?? []);
+  }, [preferences]);
+
+  const searchResults = useQuery(
+    api.ingredients.search,
+    canUsePremiumFeatures && debouncedQuery.length >= 2
+      ? { q: debouncedQuery, limit: 20 }
+      : "skip",
+  );
+  const selectedIngredientDocs = useQuery(
+    api.ingredients.getByIds,
+    allergyIngredientIds.length > 0 ? { ids: allergyIngredientIds } : "skip",
+  );
+
+  const ingredientLabels = useMemo(() => {
+    const labels = new Map<string, string>();
+    if (!selectedIngredientDocs) return labels;
+    for (const ingredient of Object.values(selectedIngredientDocs)) {
+      labels.set(
+        ingredient._id,
+        ingredient.displayName?.trim() || ingredient.name || "Ingredient",
+      );
+    }
+    return labels;
+  }, [selectedIngredientDocs]);
+
+  const toggleProtein = (protein: string) => {
+    setExcludedPrimaryProteins((prev) => {
+      if (prev.includes(protein)) return prev.filter((p) => p !== protein);
+      return [...prev, protein];
+    });
+  };
+
+  const addAllergyPhrase = () => {
+    const phrase = normalisePhrase(searchQuery);
+    if (!phrase) return;
+    if (allergyPhrases.includes(phrase)) return;
+    setAllergyPhrases((prev) => [...prev, phrase]);
+    setSearchQuery("");
+    setDebouncedQuery("");
+  };
+
+  const canAddCustomPhrase = useMemo(() => {
+    const phrase = normalisePhrase(searchQuery);
+    if (!phrase) return false;
+    return !allergyPhrases.includes(phrase);
+  }, [allergyPhrases, searchQuery]);
+
+  const addAllergyIngredient = (ingredientId: Id<"ingredients">) => {
+    if (allergyIngredientIds.includes(ingredientId)) return;
+    setAllergyIngredientIds((prev) => [...prev, ingredientId]);
+    setSearchQuery("");
+    setDebouncedQuery("");
+  };
+
+  const handleSave = async () => {
+    if (!canUsePremiumFeatures) return;
+    setIsSaving(true);
+    try {
+      await savePreferences({
+        allergyIngredientIds,
+        allergyPhrases,
+        excludedPrimaryProteins,
+      });
+      toast.success("Preferences saved");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const hasAnyPreference =
+    allergyIngredientIds.length > 0 ||
+    allergyPhrases.length > 0 ||
+    excludedPrimaryProteins.length > 0;
+
+  return (
+    <div className="container mx-auto px-4 py-6 max-w-5xl">
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="rounded-lg bg-primary/10 p-2">
+            <UserCog className="size-5 text-primary" />
+          </div>
+          <h1 className="text-3xl font-bold">Settings</h1>
+        </div>
+        <p className="text-muted-foreground max-w-2xl">
+          This is the start of your settings hub. Configure your meal-planning
+          preferences now, with account and profile settings coming next.
+        </p>
+      </div>
+
+      <div className="mb-6 grid gap-2 sm:grid-cols-3">
+        <Badge className="justify-center py-2">Preferences</Badge>
+        <Badge variant="outline" className="justify-center py-2">
+          Account (soon)
+        </Badge>
+        <Badge variant="outline" className="justify-center py-2">
+          Notifications (soon)
+        </Badge>
+      </div>
+
+      {!canUsePremiumFeatures ? (
+        <PremiumFeatureNotice
+          title="Pro feature"
+          description="Preference-based generation is available on Pro."
+        />
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)] mt-6">
+        <aside className="hidden lg:block">
+          <Card className="sticky top-20">
+            <CardHeader>
+              <CardTitle className="text-base">On this page</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <a
+                href="#allergies"
+                className="block text-muted-foreground hover:text-foreground"
+              >
+                Allergies & intolerances
+              </a>
+              <a
+                href="#proteins"
+                className="block text-muted-foreground hover:text-foreground"
+              >
+                Protein preferences
+              </a>
+            </CardContent>
+          </Card>
+        </aside>
+
+        <div className="space-y-6">
+          <Card id="allergies">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldAlert className="size-5 text-primary" />
+                Allergies & intolerances
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Add allergy items to block recipes for this profile.
+              </p>
+              <div className="rounded-md border border-amber-300/60 bg-amber-50/70 p-3 text-sm text-amber-900 dark:border-amber-700/50 dark:bg-amber-950/30 dark:text-amber-200">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+                  <p>
+                    We do our best to filter allergens, but always double-check
+                    recipes before cooking. Imported recipes can be edited to
+                    suit your needs.
+                  </p>
+                </div>
+              </div>
+
+              <div
+                className={cn(
+                  !canUsePremiumFeatures && "pointer-events-none opacity-60",
+                )}
+              >
+                <Label htmlFor="allergy-search">Search allergy items</Label>
+                <Input
+                  id="allergy-search"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter") return;
+                    if (!canAddCustomPhrase) return;
+                    event.preventDefault();
+                    addAllergyPhrase();
+                  }}
+                  placeholder="e.g. peanut, prawns, sesame"
+                  className="mt-2"
+                />
+                {debouncedQuery.length >= 2 &&
+                searchResults &&
+                searchResults.length > 0 ? (
+                  <div className="mt-2 max-h-44 overflow-auto rounded-md border">
+                    {canAddCustomPhrase ? (
+                      <button
+                        type="button"
+                        className="w-full border-b px-3 py-2 text-left text-sm font-medium text-primary hover:bg-accent"
+                        onClick={addAllergyPhrase}
+                      >
+                        Add “{searchQuery.trim()}” as allergy
+                      </button>
+                    ) : null}
+                    {searchResults.map((row) => (
+                      <button
+                        key={row._id}
+                        type="button"
+                        className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
+                        onClick={() => addAllergyIngredient(row._id)}
+                      >
+                        {row.displayName || row.name}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+                {debouncedQuery.length >= 2 &&
+                (!searchResults || searchResults.length === 0) &&
+                canAddCustomPhrase ? (
+                  <div className="mt-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={addAllergyPhrase}
+                    >
+                      Add “{searchQuery.trim()}” as allergy
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {allergyIngredientIds.map((id) => (
+                  <Badge key={id} variant="outline" className="gap-1 pr-1">
+                    {ingredientLabels.get(id) ?? "Ingredient"}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setAllergyIngredientIds((prev) =>
+                          prev.filter((x) => x !== id),
+                        )
+                      }
+                      aria-label="Remove ingredient"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </Badge>
+                ))}
+                {allergyPhrases.map((phrase) => (
+                  <Badge
+                    key={phrase}
+                    variant="outline"
+                    className="gap-1 pr-1 border-dashed"
+                  >
+                    {phrase}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setAllergyPhrases((prev) =>
+                          prev.filter((x) => x !== phrase),
+                        )
+                      }
+                      aria-label="Remove phrase"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </Badge>
+                ))}
+                {!hasAnyPreference ? (
+                  <p className="text-sm text-muted-foreground">
+                    No restrictions set.
+                  </p>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card id="proteins">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FishOff className="size-5 text-primary" />
+                Protein preferences
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                Turn off protein types you do not want to see in generated
+                plans.
+              </p>
+              <div
+                className={cn(
+                  "flex flex-wrap gap-2",
+                  !canUsePremiumFeatures && "pointer-events-none opacity-60",
+                )}
+              >
+                {proteinOptions.map((protein) => {
+                  const active = excludedPrimaryProteins.includes(protein);
+                  return (
+                    <button
+                      key={protein}
+                      type="button"
+                      className={cn(
+                        "rounded-full border px-3 py-1.5 text-sm transition-colors",
+                        active
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border text-muted-foreground hover:text-foreground",
+                      )}
+                      onClick={() => toggleProtein(protein)}
+                    >
+                      {active ? `No ${protein}` : protein}
+                    </button>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Saved preferences apply when your profile is selected during
+                  meal plan generation.
+                </p>
+              </div>
+              <div className="flex justify-end">
+                <Button
+                  onClick={handleSave}
+                  disabled={!canUsePremiumFeatures || isSaving}
+                >
+                  {isSaving ? (
+                    <Loader2 className="size-4 mr-2 animate-spin" />
+                  ) : null}
+                  Save preferences
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/preferences/page.tsx
+++ b/src/app/(app)/dashboard/preferences/page.tsx
@@ -22,7 +22,7 @@ import {
   UserCog,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 function normalisePhrase(raw: string): string {
@@ -48,6 +48,7 @@ export default function PreferencesPage() {
     string[]
   >([]);
   const [isSaving, setIsSaving] = useState(false);
+  const initializedUserIdRef = useRef<string | null>(null);
 
   const canUsePremiumFeatures = useMemo(() => {
     const tier = currentUser?.subscriptionTier ?? "free_user";
@@ -63,10 +64,13 @@ export default function PreferencesPage() {
 
   useEffect(() => {
     if (!preferences) return;
+    const currentUserId = currentUser?._id ?? null;
+    if (initializedUserIdRef.current === currentUserId) return;
     setAllergyIngredientIds(preferences.allergyIngredientIds ?? []);
     setAllergyPhrases(preferences.allergyPhrases ?? []);
     setExcludedPrimaryProteins(preferences.excludedPrimaryProteins ?? []);
-  }, [preferences]);
+    initializedUserIdRef.current = currentUserId;
+  }, [preferences, currentUser?._id]);
 
   const searchResults = useQuery(
     api.ingredients.search,
@@ -137,10 +141,8 @@ export default function PreferencesPage() {
     }
   };
 
-  const hasAnyPreference =
-    allergyIngredientIds.length > 0 ||
-    allergyPhrases.length > 0 ||
-    excludedPrimaryProteins.length > 0;
+  const hasAnyAllergyPreference =
+    allergyIngredientIds.length > 0 || allergyPhrases.length > 0;
 
   return (
     <div className="container mx-auto px-4 py-6 max-w-5xl">
@@ -317,7 +319,7 @@ export default function PreferencesPage() {
                     </button>
                   </Badge>
                 ))}
-                {!hasAnyPreference ? (
+                {!hasAnyAllergyPreference ? (
                   <p className="text-sm text-muted-foreground">
                     No restrictions set.
                   </p>

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -35,6 +35,7 @@ export const ROUTES = {
   shoppingListWithId: (listId: string) =>
     `/dashboard/shopping-list?listId=${listId}`,
   HOUSEHOLDS: "/dashboard/households",
+  PREFERENCES: "/dashboard/preferences",
   DISCOVER: "/discover",
   /** Public SEO intent landing pages (indexable). @see docs/GROWTH.md */
   FAMILY_MEAL_PLANNING: "/family-meal-planning",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preferences page to save allergies (ingredients + custom phrases) and excluded proteins; Settings menu links to it
  * Household preference generation with selectable members and member-selection UI
  * Quick-meals targeting with count, max-minutes, presets and validation
  * Duck and venison added to primary protein options

* **Improvements**
  * Premium gating, input limits, phrase normalisation and clearer error messages for household/quick-meal generation
  * Meal plans persist included members, preference snapshots and quick-meal targets; regeneration reuses them
<!-- end of auto-generated comment: release notes by coderabbit.ai -->