### PR TITLE
Add SEO and discovery enhancements with agent mapping

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,33 @@
+# Foodedo
+
+> Foodedo helps households plan weekly meals and shopping lists quickly, with curated recipes and flexible collaboration.
+
+This file provides a concise map of public pages for AI agents. Prefer these URLs for product, help, and policy information.
+
+## Core Product
+
+- [Homepage](https://foodedo.com/): Product overview, value proposition, and primary calls to action.
+- [Pricing](https://foodedo.com/pricing): Plans, feature differences, and upgrade path.
+- [Discover](https://foodedo.com/discover): Public recipe discovery experience and browse entry point.
+
+## Help and Onboarding
+
+- [Support Hub](https://foodedo.com/support): Central support landing page.
+- [How to Use](https://foodedo.com/support/how-to-use): Step-by-step usage guidance for key product flows.
+- [Contact Support](https://foodedo.com/support/contact): Support contact and assistance channel.
+- [FAQ](https://foodedo.com/faq): Frequently asked questions about product behavior and usage.
+
+## Content and Discovery
+
+- [Blog](https://foodedo.com/blog): Product updates, educational content, and launch-related posts.
+
+## Policies
+
+- [Privacy Policy](https://foodedo.com/privacy): Data handling, privacy practices, and user rights.
+- [Terms of Service](https://foodedo.com/terms): Terms governing product use.
+
+## Optional
+
+- [Family Meal Planning](https://foodedo.com/family-meal-planning): Public intent page focused on family planning use cases.
+- [Household Meal Planning](https://foodedo.com/household-meal-planning): Public intent page focused on shared household planning.
+- [Recipe to Shopping List](https://foodedo.com/recipe-to-shopping-list): Public intent page focused on converting recipe planning into shopping workflows.

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -39,10 +39,8 @@ const homeJsonLd = {
 };
 
 export const metadata: Metadata = {
-  title: {
-    /** Avoid root layout template duplicating the brand (e.g. "Foodedo | Foodedo"). */
-    absolute: homeTitle,
-  },
+  /** Explicit homepage title for root URL crawlers. */
+  title: homeTitle,
   description: homeDescription,
   keywords: [
     APP_NAME,

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -40,7 +40,7 @@ const homeJsonLd = {
 
 export const metadata: Metadata = {
   /** Explicit homepage title for root URL crawlers. */
-  title: homeTitle,
+  title: { absolute: homeTitle },
   description: homeDescription,
   keywords: [
     APP_NAME,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -14,7 +14,7 @@ export default function robots(): MetadataRoute.Robots {
         "/invite/",
         "/sign-in",
         "/sign-up",
-        "/ingest/",
+        "/ingest",
       ],
     },
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,14 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/dashboard/", "/recipe/", "/invite/"],
+      disallow: [
+        "/dashboard/",
+        "/recipe/",
+        "/invite/",
+        "/sign-in",
+        "/sign-up",
+        "/ingest/",
+      ],
     },
     sitemap: `${baseUrl}/sitemap.xml`,
   };

--- a/src/components/faq/faq-sections-panel.tsx
+++ b/src/components/faq/faq-sections-panel.tsx
@@ -1,9 +1,6 @@
 "use client";
 
 import { APP_NAME, ROUTES } from "@/app/constants";
-import { FAQ_SECTIONS_DATA } from "@/lib/faq-content";
-import { FAQ_SECTION_ACCENTS } from "@/lib/faq-section-accents";
-import { cn } from "@/lib/utils";
 import {
   Accordion,
   AccordionContent,
@@ -12,6 +9,9 @@ import {
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FAQ_SECTIONS_DATA } from "@/lib/faq-content";
+import { FAQ_SECTION_ACCENTS } from "@/lib/faq-section-accents";
+import { cn } from "@/lib/utils";
 import { ArrowLeft, HelpCircle } from "lucide-react";
 import Link from "next/link";
 
@@ -25,7 +25,10 @@ const DEFAULT_SECTION_ACCENT = {
   color: "bg-primary/10 text-primary",
 };
 
-export function FaqSectionsPanel({ backHref, backLabel }: FaqSectionsPanelProps) {
+export function FaqSectionsPanel({
+  backHref,
+  backLabel,
+}: FaqSectionsPanelProps) {
   return (
     <div className="container mx-auto px-4 py-6 max-w-4xl">
       <div className="mb-6">
@@ -91,13 +94,15 @@ export function FaqSectionsPanel({ backHref, backLabel }: FaqSectionsPanelProps)
       <Card className="mt-8">
         <CardContent className="pt-6">
           <div className="text-center">
-            <h3 className="text-lg font-semibold mb-2">Still have questions?</h3>
+            <h3 className="text-lg font-semibold mb-2">
+              Still have questions?
+            </h3>
             <p className="text-muted-foreground mb-4">
               Can&apos;t find the answer you&apos;re looking for? We&apos;re
               here to help!
             </p>
             <Button asChild>
-              <Link href={ROUTES.CONTACT}>Contact Support</Link>
+              <Link href={ROUTES.PUBLIC_SUPPORT_CONTACT}>Contact Support</Link>
             </Button>
           </div>
         </CardContent>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,6 +18,7 @@ const isPublicRoute = createRouteMatcher([
   "/discover",
   "/discover/(.*)",
   "/invite(.*)",
+  "/robots.txt",
   "/sitemap(.*)",
 ]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public documentation index to help AI agents discover Foodedo’s key pages (homepage, pricing, recipes, support, blog, legal, and optional intent pages).

* **Updates**
  * FAQ “Contact Support” link now points to the public support contact page.
  * Search engine crawling rules expanded to disallow sign-in, sign-up and certain data-ingest routes.
  * Requests for robots.txt are now treated as a public resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->