### PR TITLE
Add chalkboard item source tracking to shopping list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ The repo does not commit a machine-specific `store-dir`. To use a custom pnpm st
 - [x] Take most popular organic search results in google search console and make sure we have landing pages or blogs to capitalise.
 - [x] Better search and filtering for meal plan recipe select
 - [x] If there is a current meal plan, the meals button should take you there instead
-- [ ] Paginate recipe listings in both UI and API responses; define page size and an offset or cursor strategy.
+- [x] Paginate recipe listings in both UI and API responses; define page size and an offset or cursor strategy.
+- [x] Chalkboard items not added to shopping lists, likely because they are pantry items
+- [ ] Chicken thighs not added to shopping list even though we needed two lots, not one.
 - [ ] Manual meal selection UI card does not work on android (validate fix)
 - [ ] Build community and organic traffic, fix bugs. That is all I am allowed to do until the end of the month (April).
 - [ ] **Super-user recipe generation**: a repeatable flow (UI and/or AI) to propose and land **system-quality** recipes—constraints, meal balance, technique fit, and Convex seed workflow—as codified in [`docs/RECIPE_AUTHORING_METHODOLOGY.md`](docs/RECIPE_AUTHORING_METHODOLOGY.md). Complements batch-style prompts in [`docs/RECIPE-GENERATION-PROMPT.md`](docs/RECIPE-GENERATION-PROMPT.md).

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -323,6 +323,8 @@ export default defineSchema({
     baseAmountEntries: v.optional(v.array(amountEntryValidator)),
     // Rows manually edited by the user should not be auto-rescaled.
     amountManuallyEdited: v.optional(v.boolean()),
+    // User opted to include this via chalkboard and it should never be pantry-default excluded.
+    addedFromChalkboard: v.optional(v.boolean()),
   }).index("by_shopping_list", ["shoppingListId"]),
 
   mealPlans: defineTable({

--- a/convex/shoppingLists.ts
+++ b/convex/shoppingLists.ts
@@ -841,6 +841,7 @@ export const createShoppingList = mutation({
           amount: null,
           checked: false,
           order: baseOrder + j,
+          addedFromChalkboard: true,
         })
       )
     );
@@ -1060,6 +1061,7 @@ export const createShoppingListFromMealPlan = mutation({
           amount: null,
           checked: false,
           order: baseOrder + j,
+          addedFromChalkboard: true,
         })
       )
     );
@@ -1359,6 +1361,7 @@ export const addChalkboardItems = mutation({
           amount: null,
           checked: false,
           order: maxOrder,
+          addedFromChalkboard: true,
         });
       })
     );

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list-client.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list-client.tsx
@@ -82,7 +82,7 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import ShoppingList from "./shopping-list";
 
@@ -255,18 +255,26 @@ export default function ShoppingListClient() {
     () => buildShoppingListItems(selectedRecipes ?? [], targetServings),
     [selectedRecipes, targetServings],
   );
+  const getCanonicalKey = useCallback(
+    (item: (typeof flatIngredients)[number]) =>
+      (item.name ?? "").trim().toLowerCase(),
+    [],
+  );
   const { mainItems, pantryItems } = useMemo(() => {
     const main: typeof flatIngredients = [];
     const pantry: typeof flatIngredients = [];
     for (const item of flatIngredients) {
-      if (isPantryStaple(item.name)) {
+      if (
+        !item.addedFromChalkboard &&
+        isPantryStaple(getCanonicalKey(item))
+      ) {
         pantry.push(item);
       } else {
         main.push(item);
       }
     }
     return { mainItems: main, pantryItems: pantry };
-  }, [flatIngredients]);
+  }, [flatIngredients, getCanonicalKey]);
   const [showDoneDialog, setShowDoneDialog] = useState(false);
   const isUserRecipesInitialLoading =
     userRecipesStatus === "LoadingFirstPage" && userRecipes.length === 0;
@@ -1188,6 +1196,7 @@ const buildShoppingListItems = (
   preparation?: string | null;
   amount: number | string | null;
   ingredientId?: Id<"ingredients">;
+  addedFromChalkboard?: boolean;
   amountEntries: AmountEntry[];
   recipeIds: Id<"recipes">[];
 }> => {

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -90,7 +90,7 @@ function weeklyTotalEntriesForLeftoverItem(item: ShoppingListItem) {
   if (baseline) {
     return [{ amount: baseline.amount, unit: baseline.unit }];
   }
-  return normalizedAmountEntries(item);
+  return null;
 }
 
 function finiteNumberOrNull(value: number | string | null | undefined) {
@@ -1161,19 +1161,20 @@ export default function ShoppingList({
                       const buyUnitLabel = (first.unit ?? "").trim();
                       const weeklyTotalEntries =
                         weeklyTotalEntriesForLeftoverItem(item);
-                      const weeklyTotalSummary =
-                        amountLinesFromEntries(weeklyTotalEntries);
+                      const weeklyTotalSummary = weeklyTotalEntries
+                        ? amountLinesFromEntries(weeklyTotalEntries)
+                        : [];
                       const weeklyTotalFromBaseline = finiteNumberOrNull(
                         item.leftoverBaseline?.amount,
                       );
                       const weeklyTotalFromSingleEntry =
-                        weeklyTotalEntries.length === 1
+                        weeklyTotalEntries && weeklyTotalEntries.length === 1
                           ? finiteNumberOrNull(weeklyTotalEntries[0]?.amount)
                           : null;
                       const weeklyTotalNumeric =
                         weeklyTotalFromBaseline ?? weeklyTotalFromSingleEntry;
                       const presetBase =
-                        weeklyTotalNumeric ?? finiteNumberOrNull(first.amount);
+                        weeklyTotalNumeric ?? weeklyTotalFromSingleEntry;
                       const restSummary = rest
                         .map((e) => `${e.amount ?? ""} ${e.unit ?? ""}`.trim())
                         .filter(Boolean);
@@ -1218,9 +1219,10 @@ export default function ShoppingList({
                               <p className="text-xs text-muted-foreground shrink-0">
                                 Weekly total:{" "}
                                 <span className="font-medium text-foreground">
-                                  {weeklyTotalSummary.length > 0
+                                  {weeklyTotalEntries &&
+                                  weeklyTotalSummary.length > 0
                                     ? weeklyTotalSummary.join(" + ")
-                                    : "Not specified"}
+                                    : "Unavailable"}
                                 </span>
                               </p>
                             </div>
@@ -1267,7 +1269,7 @@ export default function ShoppingList({
                                   {buyUnitLabel}
                                 </span>
                               ) : null}
-                              {presetBase != null ? (
+                              {weeklyTotalEntries && presetBase != null ? (
                                 <div className="flex flex-wrap items-center gap-1.5">
                                   <Button
                                     type="button"

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -1,3 +1,4 @@
+import { ServingsStepper } from "@/components/servings-stepper";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -12,7 +13,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ServingsStepper } from "@/components/servings-stepper";
 import {
   Select,
   SelectContent,
@@ -31,9 +31,14 @@ import {
 import { cn } from "@/lib/utils";
 import { api } from "convex/_generated/api";
 import type { Doc, Id } from "convex/_generated/dataModel";
+import {
+  canUseServingControl,
+  TARGET_SERVINGS_MAX,
+  TARGET_SERVINGS_MIN,
+} from "convex/lib/constants";
 import { useMutation, useQuery } from "convex/react";
-import { ConvexError } from "convex/values";
 import type { FunctionReturnType } from "convex/server";
+import { ConvexError } from "convex/values";
 import {
   ArrowLeft,
   Check,
@@ -48,11 +53,6 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import {
-  canUseServingControl,
-  TARGET_SERVINGS_MAX,
-  TARGET_SERVINGS_MIN,
-} from "convex/lib/constants";
 
 type ShoppingList = NonNullable<
   FunctionReturnType<typeof api.shoppingLists.getActiveShoppingList>
@@ -119,6 +119,7 @@ function LeftoverNumericAmountInput({
   disabled: boolean;
   onCommit: (itemId: Id<"shoppingListItems">, newAmount: number) => void;
 }) {
+  const committedByEnterRef = useRef(false);
   const [amountDraft, setAmountDraft] = useState(
     Number.isFinite(amount) ? String(amount) : "",
   );
@@ -150,10 +151,15 @@ function LeftoverNumericAmountInput({
         setAmountDraft(e.target.value);
       }}
       onBlur={() => {
+        if (committedByEnterRef.current) {
+          committedByEnterRef.current = false;
+          return;
+        }
         commitDraft();
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
+          committedByEnterRef.current = true;
           commitDraft();
           (e.currentTarget as HTMLInputElement).blur();
         }
@@ -201,7 +207,8 @@ export default function ShoppingList({
   const [draftTargetServings, setDraftTargetServings] = useState(
     shoppingList.targetServings ?? TARGET_SERVINGS_MIN,
   );
-  const [isUpdatingTargetServings, setIsUpdatingTargetServings] = useState(false);
+  const [isUpdatingTargetServings, setIsUpdatingTargetServings] =
+    useState(false);
 
   // Mutations
   const toggleItemChecked = useMutation(api.shoppingLists.toggleItemChecked);
@@ -254,7 +261,9 @@ export default function ShoppingList({
     ingredientIds.length > 0 ? { ids: ingredientIds } : "skip",
   );
   const currentUser = useQuery(api.users.current);
-  const canControlServings = canUseServingControl(currentUser?.subscriptionTier);
+  const canControlServings = canUseServingControl(
+    currentUser?.subscriptionTier,
+  );
   const isDev =
     process.env.NODE_ENV !== "production" ||
     process.env.NEXT_PUBLIC_SHOW_RECIPE_LINKS === "true";
@@ -287,9 +296,15 @@ export default function ShoppingList({
   };
   const getAmountLines = (item: (typeof shoppingList.items)[number]) =>
     amountLinesFromEntries(normalizedAmountEntries(item));
-  const renderChalkboardBadge = (item: ShoppingListItem) =>
+  const renderChalkboardBadge = (
+    item: ShoppingListItem,
+    options?: { className?: string },
+  ) =>
     item.addedFromChalkboard ? (
-      <Badge variant="secondary" className="ml-2 text-[10px] leading-4">
+      <Badge
+        variant="secondary"
+        className={cn("text-[10px] leading-4", options?.className)}
+      >
         Chalkboard item
       </Badge>
     ) : null;
@@ -469,10 +484,7 @@ export default function ShoppingList({
   const availableChalkboardItemsCount = getAvailableChalkboardCount();
 
   const commitItemAmount = useCallback(
-    async (
-      itemId: Id<"shoppingListItems">,
-      amount: number | string | null,
-    ) => {
+    async (itemId: Id<"shoppingListItems">, amount: number | string | null) => {
       try {
         await updateItemAmount({ itemId, amount });
       } catch (error) {
@@ -603,7 +615,11 @@ export default function ShoppingList({
         setIsUpdatingTargetServings(false);
       }
     },
-    [draftTargetServings, shoppingList._id, updateDraftShoppingListTargetServings],
+    [
+      draftTargetServings,
+      shoppingList._id,
+      updateDraftShoppingListTargetServings,
+    ],
   );
 
   const handleAddFromChalkboard = async () => {
@@ -752,7 +768,7 @@ export default function ShoppingList({
                               <> ({getOriginalRecipeName(item)})</>
                             )}
                         </span>
-                        {renderChalkboardBadge(item)}
+                        {renderChalkboardBadge(item, { className: "ml-2" })}
                         {getAmountLines(item).length > 0 && (
                           <span className="ml-2">
                             {getAmountLines(item).join(", ")}
@@ -786,7 +802,7 @@ export default function ShoppingList({
                         <span className={cn(item.checked && "line-through")}>
                           {getDisplayName(item)}
                         </span>
-                        {renderChalkboardBadge(item)}
+                        {renderChalkboardBadge(item, { className: "ml-2" })}
                         {getAmountLines(item).length > 0 && (
                           <span className="ml-2">
                             {getAmountLines(item).join(", ")}
@@ -825,7 +841,7 @@ export default function ShoppingList({
                               <> ({getOriginalRecipeName(item)})</>
                             )}
                         </span>
-                        {renderChalkboardBadge(item)}
+                        {renderChalkboardBadge(item, { className: "ml-2" })}
                         {getAmountLines(item).length > 0 && (
                           <span className="ml-2">
                             {getAmountLines(item).join(", ")}
@@ -911,7 +927,9 @@ export default function ShoppingList({
                           listId: shoppingList._id,
                           visibility: "owner_only",
                         });
-                        toast.success("Household sharing removed from this list");
+                        toast.success(
+                          "Household sharing removed from this list",
+                        );
                         return;
                       }
                       const prefix = "household:";
@@ -962,8 +980,8 @@ export default function ShoppingList({
                 {shoppingList.mealPlanId ? (
                   <p className="text-xs text-muted-foreground pt-1">
                     Linked to a meal plan: &quot;Only me&quot; isn&apos;t
-                    available (the link must stay meaningful for the plan).
-                    Use &quot;Not shared via household&quot; to stop household
+                    available (the link must stay meaningful for the plan). Use
+                    &quot;Not shared via household&quot; to stop household
                     visibility; people who can open the plan may still see this
                     list.
                   </p>
@@ -1083,9 +1101,8 @@ export default function ShoppingList({
                       const buyUnitLabel = (first.unit ?? "").trim();
                       const weeklyTotalEntries =
                         weeklyTotalEntriesForLeftoverItem(item);
-                      const weeklyTotalSummary = amountLinesFromEntries(
-                        weeklyTotalEntries,
-                      );
+                      const weeklyTotalSummary =
+                        amountLinesFromEntries(weeklyTotalEntries);
                       const weeklyTotalFromBaseline = finiteNumberOrNull(
                         item.leftoverBaseline?.amount,
                       );
@@ -1098,10 +1115,7 @@ export default function ShoppingList({
                       const presetBase =
                         weeklyTotalNumeric ?? finiteNumberOrNull(first.amount);
                       const restSummary = rest
-                        .map(
-                          (e) =>
-                            `${e.amount ?? ""} ${e.unit ?? ""}`.trim(),
-                        )
+                        .map((e) => `${e.amount ?? ""} ${e.unit ?? ""}`.trim())
                         .filter(Boolean);
                       return (
                         <li
@@ -1255,10 +1269,10 @@ export default function ShoppingList({
                         ingredientsMap={ingredientsMap}
                         getDisplayName={getDisplayName}
                         getOriginalRecipeName={getOriginalRecipeName}
-                        getAmountLines={getAmountLines}
                         onAmountChange={handleAmountChange}
                         onRemove={handleRemoveItem}
                         onToggleChecked={handleCheckItem}
+                        renderChalkboardBadge={renderChalkboardBadge}
                       />
                     ))}
                   </div>
@@ -1609,10 +1623,10 @@ function ShoppingListScreenItemRow({
   ingredientsMap,
   getDisplayName,
   getOriginalRecipeName,
-  getAmountLines,
   onAmountChange,
   onRemove,
   onToggleChecked,
+  renderChalkboardBadge,
 }: {
   item: ShoppingListItem;
   isFinalised: boolean;
@@ -1620,10 +1634,13 @@ function ShoppingListScreenItemRow({
   ingredientsMap: Record<Id<"ingredients">, Doc<"ingredients">> | undefined;
   getDisplayName: (item: ShoppingListItem) => string;
   getOriginalRecipeName: (item: ShoppingListItem) => string;
-  getAmountLines: (item: ShoppingListItem) => string[];
   onAmountChange: (itemId: Id<"shoppingListItems">, newAmount: number) => void;
   onRemove: (itemId: Id<"shoppingListItems">) => void;
   onToggleChecked: (itemId: Id<"shoppingListItems">) => void;
+  renderChalkboardBadge: (
+    item: ShoppingListItem,
+    options?: { className?: string },
+  ) => React.ReactNode;
 }) {
   return (
     <div
@@ -1660,11 +1677,7 @@ function ShoppingListScreenItemRow({
                 </span>
               )}
           </p>
-          {item.addedFromChalkboard ? (
-            <Badge variant="secondary" className="text-[10px] leading-4">
-              Chalkboard item
-            </Badge>
-          ) : null}
+          {renderChalkboardBadge(item)}
         </div>
 
         {(() => {

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -82,6 +82,28 @@ function firstAmountEntryForItem(item: ShoppingListItem) {
   return { first, rest: entries.slice(1) };
 }
 
+function weeklyTotalEntriesForLeftoverItem(item: ShoppingListItem) {
+  const baseline = item.leftoverBaseline;
+  if (baseline?.amountEntries && baseline.amountEntries.length > 0) {
+    return baseline.amountEntries;
+  }
+  if (baseline) {
+    return [{ amount: baseline.amount, unit: baseline.unit }];
+  }
+  return normalizedAmountEntries(item);
+}
+
+function finiteNumberOrNull(value: number | string | null | undefined) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 function namesEqual(a: string, b: string): boolean {
   return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
@@ -948,34 +970,10 @@ export default function ShoppingList({
                   />
                 </div>
               ) : null}
-              {ingredientsByCategory.map(({ category, items }) => (
-                <div key={category}>
-                  <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-                    {category}
-                  </h4>
-                  <div className="space-y-2">
-                    {items.map((item) => (
-                      <ShoppingListScreenItemRow
-                        key={item._id}
-                        item={item}
-                        isFinalised={isFinalised}
-                        isDev={isDev}
-                        ingredientsMap={ingredientsMap}
-                        getDisplayName={getDisplayName}
-                        getOriginalRecipeName={getOriginalRecipeName}
-                        getAmountLines={getAmountLines}
-                        onAmountChange={handleAmountChange}
-                        onRemove={handleRemoveItem}
-                        onToggleChecked={handleCheckItem}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))}
               {!isFinalised && mealPlanLeftoverItems.length > 0 ? (
                 <div
                   className={cn(
-                    "border-t border-border pt-6 space-y-4 rounded-lg border p-4",
+                    "space-y-4 rounded-lg border p-4",
                     "border-amber-500/35 bg-amber-500/5",
                   )}
                 >
@@ -984,9 +982,8 @@ export default function ShoppingList({
                       Already have (from your meal plan)
                     </h4>
                     <p className="text-xs text-muted-foreground">
-                      Check what you need on this shop trip. Edit the amount
-                      (e.g. grams) for each line — change it to whatever you
-                      actually need to buy.
+                      Weekly total is shown first for each ingredient. Set how
+                      much to buy this trip with quick presets or manual edits.
                     </p>
                   </div>
                   <ul className="space-y-3">
@@ -995,7 +992,23 @@ export default function ShoppingList({
                         item._id,
                       );
                       const { first, rest } = firstAmountEntryForItem(item);
-                      const unitLabel = (first.unit ?? "").trim();
+                      const buyUnitLabel = (first.unit ?? "").trim();
+                      const weeklyTotalEntries =
+                        weeklyTotalEntriesForLeftoverItem(item);
+                      const weeklyTotalSummary = amountLinesFromEntries(
+                        weeklyTotalEntries,
+                      );
+                      const weeklyTotalFromBaseline = finiteNumberOrNull(
+                        item.leftoverBaseline?.amount,
+                      );
+                      const weeklyTotalFromSingleEntry =
+                        weeklyTotalEntries.length === 1
+                          ? finiteNumberOrNull(weeklyTotalEntries[0]?.amount)
+                          : null;
+                      const weeklyTotalNumeric =
+                        weeklyTotalFromBaseline ?? weeklyTotalFromSingleEntry;
+                      const presetBase =
+                        weeklyTotalNumeric ?? finiteNumberOrNull(first.amount);
                       const restSummary = rest
                         .map(
                           (e) =>
@@ -1012,34 +1025,47 @@ export default function ShoppingList({
                               : "border-primary/35 bg-primary/5",
                           )}
                         >
-                          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
-                            <label className="flex cursor-pointer items-start gap-2 shrink-0">
-                              <Checkbox
-                                checked={!excluded}
-                                onCheckedChange={(v) => {
-                                  setLeftoverExcludedFromTripIds((prev) => {
-                                    const next = new Set(prev);
-                                    if (v === true) next.delete(item._id);
-                                    else next.add(item._id);
-                                    return next;
-                                  });
-                                }}
-                                className="size-4 mt-0.5 shrink-0"
-                              />
-                              <span className="text-sm font-medium capitalize leading-snug">
-                                {getDisplayName(item)}
-                                {isDev &&
-                                  item.ingredientId &&
-                                  ingredientsMap?.[item.ingredientId] && (
-                                    <span className="text-muted-foreground font-normal normal-case">
-                                      {" "}
-                                      ({getOriginalRecipeName(item)})
-                                    </span>
-                                  )}
+                          <div className="flex flex-col gap-3">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <label className="flex cursor-pointer items-start gap-2 min-w-0">
+                                <Checkbox
+                                  checked={!excluded}
+                                  onCheckedChange={(v) => {
+                                    setLeftoverExcludedFromTripIds((prev) => {
+                                      const next = new Set(prev);
+                                      if (v === true) next.delete(item._id);
+                                      else next.add(item._id);
+                                      return next;
+                                    });
+                                  }}
+                                  className="size-4 mt-0.5 shrink-0"
+                                />
+                                <span className="text-sm font-medium capitalize leading-snug">
+                                  {getDisplayName(item)}
+                                  {isDev &&
+                                    item.ingredientId &&
+                                    ingredientsMap?.[item.ingredientId] && (
+                                      <span className="text-muted-foreground font-normal normal-case">
+                                        {" "}
+                                        ({getOriginalRecipeName(item)})
+                                      </span>
+                                    )}
+                                </span>
+                                {renderChalkboardBadge(item)}
+                              </label>
+                              <p className="text-xs text-muted-foreground shrink-0">
+                                Weekly total:{" "}
+                                <span className="font-medium text-foreground">
+                                  {weeklyTotalSummary.length > 0
+                                    ? weeklyTotalSummary.join(" + ")
+                                    : "Not specified"}
+                                </span>
+                              </p>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="text-xs text-muted-foreground">
+                                Buy this trip:
                               </span>
-                              {renderChalkboardBadge(item)}
-                            </label>
-                            <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0 sm:justify-end">
                               {typeof first.amount === "number" ? (
                                 <Input
                                   type="number"
@@ -1051,6 +1077,7 @@ export default function ShoppingList({
                                       ? first.amount
                                       : ""
                                   }
+                                  disabled={excluded}
                                   onChange={(e) => {
                                     const raw = e.target.value;
                                     if (raw === "") {
@@ -1076,6 +1103,7 @@ export default function ShoppingList({
                                       ? String(first.amount)
                                       : ""
                                   }
+                                  disabled={excluded}
                                   onBlur={(e) => {
                                     const v = e.target.value.trim();
                                     void commitItemAmount(
@@ -1085,16 +1113,62 @@ export default function ShoppingList({
                                   }}
                                 />
                               )}
-                              {unitLabel ? (
+                              {buyUnitLabel ? (
                                 <span className="text-sm text-muted-foreground shrink-0">
-                                  {unitLabel}
+                                  {buyUnitLabel}
                                 </span>
+                              ) : null}
+                              {presetBase != null ? (
+                                <div className="flex flex-wrap items-center gap-1.5">
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-7 px-2 text-xs"
+                                    disabled={excluded}
+                                    onClick={() =>
+                                      void handleAmountChange(item._id, 0)
+                                    }
+                                  >
+                                    0%
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-7 px-2 text-xs"
+                                    disabled={excluded}
+                                    onClick={() =>
+                                      void handleAmountChange(
+                                        item._id,
+                                        Math.max(0, presetBase * 0.5),
+                                      )
+                                    }
+                                  >
+                                    50%
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-7 px-2 text-xs"
+                                    disabled={excluded}
+                                    onClick={() =>
+                                      void handleAmountChange(
+                                        item._id,
+                                        Math.max(0, presetBase),
+                                      )
+                                    }
+                                  >
+                                    100%
+                                  </Button>
+                                </div>
                               ) : null}
                             </div>
                           </div>
                           {restSummary.length > 0 ? (
                             <p className="text-[11px] text-muted-foreground mt-2 pl-6 sm:pl-0">
-                              Also in this week&apos;s total:{" "}
+                              Extra split amounts on this row:{" "}
                               {restSummary.join(" · ")}
                             </p>
                           ) : null}
@@ -1104,6 +1178,30 @@ export default function ShoppingList({
                   </ul>
                 </div>
               ) : null}
+              {ingredientsByCategory.map(({ category, items }) => (
+                <div key={category}>
+                  <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                    {category}
+                  </h4>
+                  <div className="space-y-2">
+                    {items.map((item) => (
+                      <ShoppingListScreenItemRow
+                        key={item._id}
+                        item={item}
+                        isFinalised={isFinalised}
+                        isDev={isDev}
+                        ingredientsMap={ingredientsMap}
+                        getDisplayName={getDisplayName}
+                        getOriginalRecipeName={getOriginalRecipeName}
+                        getAmountLines={getAmountLines}
+                        onAmountChange={handleAmountChange}
+                        onRemove={handleRemoveItem}
+                        onToggleChecked={handleCheckItem}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
               {!isFinalised && pantryStapleItems.length > 0 ? (
                 <div className="border-t border-border pt-6 space-y-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -1173,8 +1173,7 @@ export default function ShoppingList({
                           : null;
                       const weeklyTotalNumeric =
                         weeklyTotalFromBaseline ?? weeklyTotalFromSingleEntry;
-                      const presetBase =
-                        weeklyTotalNumeric ?? weeklyTotalFromSingleEntry;
+                      const presetBase = weeklyTotalNumeric;
                       const restSummary = rest
                         .map((e) => `${e.amount ?? ""} ${e.unit ?? ""}`.trim())
                         .filter(Boolean);

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -208,10 +208,16 @@ export default function ShoppingList({
   };
   const getAmountLines = (item: (typeof shoppingList.items)[number]) =>
     amountLinesFromEntries(normalizedAmountEntries(item));
+  const renderChalkboardBadge = (item: ShoppingListItem) =>
+    item.addedFromChalkboard ? (
+      <Badge variant="secondary" className="ml-2 text-[10px] leading-4">
+        Chalkboard item
+      </Badge>
+    ) : null;
   const { mainShoppingItems, pantryStapleItems, mealPlanLeftoverItems } =
     useMemo(() => {
       const staple = (item: ShoppingListItem) =>
-        isPantryStaple(getCanonicalKey(item));
+        !item.addedFromChalkboard && isPantryStaple(getCanonicalKey(item));
       const main: ShoppingListItem[] = [];
       const pantry: ShoppingListItem[] = [];
       const leftover: ShoppingListItem[] = [];
@@ -636,6 +642,7 @@ export default function ShoppingList({
                               <> ({getOriginalRecipeName(item)})</>
                             )}
                         </span>
+                        {renderChalkboardBadge(item)}
                         {getAmountLines(item).length > 0 && (
                           <span className="ml-2">
                             {getAmountLines(item).join(", ")}
@@ -669,6 +676,7 @@ export default function ShoppingList({
                         <span className={cn(item.checked && "line-through")}>
                           {getDisplayName(item)}
                         </span>
+                        {renderChalkboardBadge(item)}
                         {getAmountLines(item).length > 0 && (
                           <span className="ml-2">
                             {getAmountLines(item).join(", ")}
@@ -707,6 +715,7 @@ export default function ShoppingList({
                               <> ({getOriginalRecipeName(item)})</>
                             )}
                         </span>
+                        {renderChalkboardBadge(item)}
                         {getAmountLines(item).length > 0 && (
                           <span className="ml-2">
                             {getAmountLines(item).join(", ")}
@@ -1028,6 +1037,7 @@ export default function ShoppingList({
                                     </span>
                                   )}
                               </span>
+                              {renderChalkboardBadge(item)}
                             </label>
                             <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0 sm:justify-end">
                               {typeof first.amount === "number" ? (
@@ -1167,6 +1177,7 @@ export default function ShoppingList({
                                   </span>
                                 )}
                             </span>
+                            {renderChalkboardBadge(item)}
                             {amtSummary ? (
                               <span className="text-xs text-muted-foreground mt-1 block">
                                 {amtSummary}
@@ -1489,6 +1500,11 @@ function ShoppingListScreenItemRow({
                 </span>
               )}
           </p>
+          {item.addedFromChalkboard ? (
+            <Badge variant="secondary" className="text-[10px] leading-4">
+              Chalkboard item
+            </Badge>
+          ) : null}
         </div>
 
         {(() => {

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -533,6 +533,66 @@ export default function ShoppingList({
     [commitItemAmount, updateMealPlanLeftoverShoppingItem],
   );
 
+  const applyManualLeftoverAmount = useCallback(
+    async (
+      item: ShoppingListItem,
+      nextAmount: number | string | null,
+      baselineAmount: number | null,
+    ) => {
+      const fallbackToDirectAmount = async () => {
+        await commitItemAmount(item._id, nextAmount);
+      };
+
+      if (
+        item.mealPlanLeftoverIngredientId === undefined ||
+        item.leftoverBaseline === undefined
+      ) {
+        await fallbackToDirectAmount();
+        return;
+      }
+
+      const numericNext = finiteNumberOrNull(nextAmount);
+      if (numericNext == null) {
+        await fallbackToDirectAmount();
+        return;
+      }
+
+      try {
+        if (baselineAmount != null && baselineAmount > 0) {
+          const scale = Math.max(0, numericNext / baselineAmount);
+          if (Math.abs(scale - 1) < 1e-6) {
+            await updateMealPlanLeftoverShoppingItem({
+              itemId: item._id,
+              mode: "full",
+            });
+          } else {
+            await updateMealPlanLeftoverShoppingItem({
+              itemId: item._id,
+              mode: "reduced",
+              reducedScale: scale,
+            });
+          }
+          return;
+        }
+
+        if (baselineAmount === 0 && numericNext === 0) {
+          await updateMealPlanLeftoverShoppingItem({
+            itemId: item._id,
+            mode: "reduced",
+            reducedScale: 0,
+          });
+          return;
+        }
+
+        await fallbackToDirectAmount();
+      } catch (error) {
+        console.error("Failed to apply leftover manual amount:", error);
+        toast.error("Failed to update amount");
+      }
+    },
+    [commitItemAmount, updateMealPlanLeftoverShoppingItem],
+  );
+
   const handleRemoveItem = async (itemId: Id<"shoppingListItems">) => {
     try {
       await removeItem({ itemId });
@@ -1173,7 +1233,13 @@ export default function ShoppingList({
                                   itemId={item._id}
                                   amount={first.amount}
                                   disabled={excluded}
-                                  onCommit={handleAmountChange}
+                                  onCommit={(_itemId, newAmount) => {
+                                    void applyManualLeftoverAmount(
+                                      item,
+                                      Math.max(0, newAmount),
+                                      presetBase,
+                                    );
+                                  }}
                                 />
                               ) : (
                                 <Input
@@ -1188,9 +1254,10 @@ export default function ShoppingList({
                                   disabled={excluded}
                                   onBlur={(e) => {
                                     const v = e.target.value.trim();
-                                    void commitItemAmount(
-                                      item._id,
-                                      v === "" ? null : v,
+                                    void applyManualLeftoverAmount(
+                                      item,
+                                      v === "" ? 0 : v,
+                                      presetBase,
                                     );
                                   }}
                                 />

--- a/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
+++ b/src/app/(app)/dashboard/shopping-list/_components/shopping-list.tsx
@@ -108,6 +108,60 @@ function namesEqual(a: string, b: string): boolean {
   return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
 
+function LeftoverNumericAmountInput({
+  itemId,
+  amount,
+  disabled,
+  onCommit,
+}: {
+  itemId: Id<"shoppingListItems">;
+  amount: number;
+  disabled: boolean;
+  onCommit: (itemId: Id<"shoppingListItems">, newAmount: number) => void;
+}) {
+  const [amountDraft, setAmountDraft] = useState(
+    Number.isFinite(amount) ? String(amount) : "",
+  );
+
+  useEffect(() => {
+    setAmountDraft(Number.isFinite(amount) ? String(amount) : "");
+  }, [itemId, amount]);
+
+  const commitDraft = useCallback(() => {
+    const next = amountDraft.trim();
+    if (next === "") {
+      onCommit(itemId, 0);
+      return;
+    }
+    const parsed = Number(next);
+    if (!Number.isFinite(parsed)) return;
+    onCommit(itemId, Math.max(0, parsed));
+  }, [amountDraft, itemId, onCommit]);
+
+  return (
+    <Input
+      type="number"
+      min={0}
+      step="any"
+      className="h-8 w-28 font-medium tabular-nums"
+      value={amountDraft}
+      disabled={disabled}
+      onChange={(e) => {
+        setAmountDraft(e.target.value);
+      }}
+      onBlur={() => {
+        commitDraft();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          commitDraft();
+          (e.currentTarget as HTMLInputElement).blur();
+        }
+      }}
+    />
+  );
+}
+
 interface ShoppingListProps {
   shoppingList: ShoppingList;
   /** For in-app sharing controls (owner only); distinct from chalkboard household query below. */
@@ -159,6 +213,9 @@ export default function ShoppingList({
   );
   const updateDraftShoppingListTargetServings = useMutation(
     api.shoppingLists.updateDraftShoppingListTargetServings,
+  );
+  const updateMealPlanLeftoverShoppingItem = useMutation(
+    api.shoppingLists.updateMealPlanLeftoverShoppingItem,
   );
   const updateShoppingListSharing = useMutation(
     api.shoppingLists.updateShoppingListSharing,
@@ -432,6 +489,37 @@ export default function ShoppingList({
   ) => {
     void commitItemAmount(itemId, Math.max(0, newAmount));
   };
+
+  const applyLeftoverPreset = useCallback(
+    async (item: ShoppingListItem, scale: number) => {
+      if (
+        item.mealPlanLeftoverIngredientId !== undefined &&
+        item.leftoverBaseline !== undefined
+      ) {
+        try {
+          if (scale >= 1) {
+            await updateMealPlanLeftoverShoppingItem({
+              itemId: item._id,
+              mode: "full",
+            });
+          } else {
+            await updateMealPlanLeftoverShoppingItem({
+              itemId: item._id,
+              mode: "reduced",
+              reducedScale: Math.max(0, scale),
+            });
+          }
+        } catch (error) {
+          console.error("Failed to apply leftover preset:", error);
+          toast.error("Failed to update amount");
+        }
+        return;
+      }
+      const current = finiteNumberOrNull(item.amount) ?? 0;
+      void commitItemAmount(item._id, Math.max(0, current * scale));
+    },
+    [commitItemAmount, updateMealPlanLeftoverShoppingItem],
+  );
 
   const handleRemoveItem = async (itemId: Id<"shoppingListItems">) => {
     try {
@@ -1067,31 +1155,11 @@ export default function ShoppingList({
                                 Buy this trip:
                               </span>
                               {typeof first.amount === "number" ? (
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step="any"
-                                  className="h-8 w-28 font-medium tabular-nums"
-                                  value={
-                                    Number.isFinite(first.amount)
-                                      ? first.amount
-                                      : ""
-                                  }
+                                <LeftoverNumericAmountInput
+                                  itemId={item._id}
+                                  amount={first.amount}
                                   disabled={excluded}
-                                  onChange={(e) => {
-                                    const raw = e.target.value;
-                                    if (raw === "") {
-                                      void handleAmountChange(item._id, 0);
-                                      return;
-                                    }
-                                    const n = Number(raw);
-                                    if (Number.isFinite(n)) {
-                                      void handleAmountChange(
-                                        item._id,
-                                        Math.max(0, n),
-                                      );
-                                    }
-                                  }}
+                                  onCommit={handleAmountChange}
                                 />
                               ) : (
                                 <Input
@@ -1127,7 +1195,7 @@ export default function ShoppingList({
                                     className="h-7 px-2 text-xs"
                                     disabled={excluded}
                                     onClick={() =>
-                                      void handleAmountChange(item._id, 0)
+                                      void applyLeftoverPreset(item, 0)
                                     }
                                   >
                                     0%
@@ -1139,10 +1207,7 @@ export default function ShoppingList({
                                     className="h-7 px-2 text-xs"
                                     disabled={excluded}
                                     onClick={() =>
-                                      void handleAmountChange(
-                                        item._id,
-                                        Math.max(0, presetBase * 0.5),
-                                      )
+                                      void applyLeftoverPreset(item, 0.5)
                                     }
                                   >
                                     50%
@@ -1154,10 +1219,7 @@ export default function ShoppingList({
                                     className="h-7 px-2 text-xs"
                                     disabled={excluded}
                                     onClick={() =>
-                                      void handleAmountChange(
-                                        item._id,
-                                        Math.max(0, presetBase),
-                                      )
+                                      void applyLeftoverPreset(item, 1)
                                     }
                                   >
                                     100%


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - "Chalkboard item" badge on items added from the chalkboard
  - Weekly total summary and preset controls (0%, 50%, 100%) for meal-plan leftovers
  - Improved numeric input behaviour for leftover amounts
  - Pantry-staple detection now uses a canonical-name approach and excludes chalkboard-added items

* **Bug Fixes**
  - Fixed issue preventing chalkboard entries from being added to shopping lists

* **Documentation**
  - README updated: recipe pagination marked completed; one shopping-list bug remains open
<!-- end of auto-generated comment: release notes by coderabbit.ai -->