### PR TITLE
feat: add recent meal plan history retrieval and UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The repo does not commit a machine-specific `store-dir`. To use a custom pnpm st
       ght ConvexError: Date must be on or before the plan end date
       at assertValidEntryPlacement (../../convex/mealPlans.ts:328:11)
       at handler (../../convex/mealPlans.ts:1634:32)
+- [x] Need means to view older meal plans up to 2 weeks. Over 4 weeks should be deleted.
+- [ ] Load more behaviour is not working as expected on filtered lists, not showing the correct additional amount after clicked. Not responding to the initial click only the second. Loading states are not correct changing before the new data is in. Still shows the button even though there are no more results (possible just when results are filtered)
 - [ ] Manual meal selection UI card does not work on android (validate fix)
 - [ ] Build community and organic traffic, fix bugs. That is all I am allowed to do until the end of the month (April).
 - [ ] **Super-user recipe generation**: a repeatable flow (UI and/or AI) to propose and land **system-quality** recipes—constraints, meal balance, technique fit, and Convex seed workflow—as codified in [`docs/RECIPE_AUTHORING_METHODOLOGY.md`](docs/RECIPE_AUTHORING_METHODOLOGY.md). Complements batch-style prompts in [`docs/RECIPE-GENERATION-PROMPT.md`](docs/RECIPE-GENERATION-PROMPT.md).

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -43,6 +43,8 @@ import {
 import { getCurrentUser, getCurrentUserOrThrow } from "./users";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const MEAL_PLAN_RETENTION_DAYS = 28;
+const MEAL_PLAN_RETENTION_MS = MEAL_PLAN_RETENTION_DAYS * ONE_DAY_MS;
 
 function phraseDisplayLabel(normalised: string): string {
   return normalised
@@ -780,6 +782,77 @@ export const getActiveMealPlanSummaries = query({
       entryCount: s.entryCount,
       entryMinDate: s.entryMinDate,
       entryMaxDate: s.entryMaxDate,
+    }));
+  },
+});
+
+/**
+ * Recent historical meal plans (ended before viewer's local day, within 4 weeks)
+ * for optional history UI. Excludes superseded plans.
+ */
+export const getRecentMealPlanHistory = query({
+  args: {
+    localDayStartMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) return [];
+
+    const refLocalStart = resolveLocalDayRefMs(args.localDayStartMs);
+    const cutoffStart = startOfDayMs(refLocalStart - MEAL_PLAN_RETENTION_MS);
+
+    const ownedPlans = await ctx.db
+      .query("mealPlans")
+      .withIndex("by_user_and_endDate", (q) =>
+        q
+          .eq("userId", user._id)
+          .gte("endDate", cutoffStart)
+          .lt("endDate", refLocalStart),
+      )
+      .order("desc")
+      .collect();
+
+    const memberships = await ctx.db
+      .query("householdMembers")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+    const householdIds = memberships.map((m) => m.householdId);
+
+    const sharedPlanGroups = await Promise.all(
+      householdIds.map((householdId) =>
+        ctx.db
+          .query("mealPlans")
+          .withIndex("by_household_and_endDate", (q) =>
+            q
+              .eq("householdId", householdId)
+              .gte("endDate", cutoffStart)
+              .lt("endDate", refLocalStart),
+          )
+          .order("desc")
+          .collect(),
+      ),
+    );
+
+    const seenIds = new Set<Id<"mealPlans">>();
+    const recentPlans = [...ownedPlans, ...sharedPlanGroups.flat()]
+      .filter((plan) => {
+        if (plan.replacedByPlanId !== undefined) return false;
+        if (seenIds.has(plan._id)) return false;
+        seenIds.add(plan._id);
+        return true;
+      })
+      .sort(
+        (a, b) => b.endDate - a.endDate || (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+      );
+
+    return recentPlans.map((plan) => ({
+      _id: plan._id,
+      startDate: plan.startDate,
+      endDate: plan.endDate,
+      isFinalised: plan.isFinalised === true,
+      updatedAt: plan.updatedAt,
+      isOwner: plan.userId === user._id,
+      householdId: plan.householdId,
     }));
   },
 });
@@ -1863,3 +1936,4 @@ export const deleteMealPlan = mutation({
     return { success: true };
   },
 });
+

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -231,6 +231,9 @@ type MealPlanClientProps = {
 type MealPlanSummary = NonNullable<
   FunctionReturnType<typeof api.mealPlans.getActiveMealPlanSummaries>
 >[number];
+type MealPlanHistorySummary = NonNullable<
+  FunctionReturnType<typeof api.mealPlans.getRecentMealPlanHistory>
+>[number];
 
 type QuickMealsPresetId = "automatic" | "light" | "balanced" | "fast_focused";
 
@@ -625,6 +628,9 @@ export default function MealPlanClient({
   const planSummaries = useQuery(api.mealPlans.getActiveMealPlanSummaries, {
     localDayStartMs,
   });
+  const recentPlanHistory = useQuery(api.mealPlans.getRecentMealPlanHistory, {
+    localDayStartMs,
+  });
   const ownedPlanCountForCreation = useQuery(
     api.mealPlans.getOwnedUnreplacedPlanCountForCreation,
     { localDayStartMs },
@@ -735,6 +741,7 @@ export default function MealPlanClient({
   const [showDeletePlanDialog, setShowDeletePlanDialog] = useState(false);
   const [showUnshareConfirmDialog, setShowUnshareConfirmDialog] =
     useState(false);
+  const [showRecentPlansDialog, setShowRecentPlansDialog] = useState(false);
   const [showFinaliseDialog, setShowFinaliseDialog] = useState(false);
   const [showEditDatesDialog, setShowEditDatesDialog] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -749,7 +756,9 @@ export default function MealPlanClient({
   const [isFinalising, setIsFinalising] = useState(false);
   const [isUpdatingDateWindow, setIsUpdatingDateWindow] = useState(false);
   const [editStartDateInput, setEditStartDateInput] = useState("");
-  const [editDayCount, setEditDayCount] = useState(String(MAX_DAYS_IN_MEAL_PLAN));
+  const [editDayCount, setEditDayCount] = useState(
+    String(MAX_DAYS_IN_MEAL_PLAN),
+  );
   const [includedMemberIds, setIncludedMemberIds] = useState<Set<Id<"users">>>(
     new Set(),
   );
@@ -935,12 +944,16 @@ export default function MealPlanClient({
           parsed.stage === "non_allergy_relaxed")
       ) {
         setGenerationFallbackStage(parsed.stage);
-        sessionStorage.removeItem(MEAL_PLAN_GENERATION_FALLBACK_NOTICE_SESSION_KEY);
+        sessionStorage.removeItem(
+          MEAL_PLAN_GENERATION_FALLBACK_NOTICE_SESSION_KEY,
+        );
       } else if (parsed.planId !== currentPlan._id) {
         setGenerationFallbackStage(null);
       }
     } catch {
-      sessionStorage.removeItem(MEAL_PLAN_GENERATION_FALLBACK_NOTICE_SESSION_KEY);
+      sessionStorage.removeItem(
+        MEAL_PLAN_GENERATION_FALLBACK_NOTICE_SESSION_KEY,
+      );
     }
   }, [currentPlan, generationOnly]);
 
@@ -1420,7 +1433,9 @@ export default function MealPlanClient({
       parsedDayCount < 1 ||
       parsedDayCount > MAX_DAYS_IN_MEAL_PLAN
     ) {
-      toast.error(`Plan length must be between 1 and ${MAX_DAYS_IN_MEAL_PLAN} days.`);
+      toast.error(
+        `Plan length must be between 1 and ${MAX_DAYS_IN_MEAL_PLAN} days.`,
+      );
       return;
     }
     setIsUpdatingDateWindow(true);
@@ -1450,12 +1465,7 @@ export default function MealPlanClient({
     } finally {
       setIsUpdatingDateWindow(false);
     }
-  }, [
-    currentPlan,
-    editDayCount,
-    editStartDateInput,
-    updatePlanDateWindow,
-  ]);
+  }, [currentPlan, editDayCount, editStartDateInput, updatePlanDateWindow]);
 
   const handlePickerSelect = useCallback(
     async (recipeId: Id<"recipes">) => {
@@ -1463,8 +1473,11 @@ export default function MealPlanClient({
       try {
         if (pickerState.mode === "add") {
           const date =
-            pickerState.targetDate ?? (currentPlan.startDate ?? currentPlan.endDate);
-          const order = pickerState.targetOrder ?? (currentPlan.entries?.length ?? 0);
+            pickerState.targetDate ??
+            currentPlan.startDate ??
+            currentPlan.endDate;
+          const order =
+            pickerState.targetOrder ?? currentPlan.entries?.length ?? 0;
           await addEntry({
             mealPlanId: currentPlan._id,
             date,
@@ -2070,12 +2083,12 @@ export default function MealPlanClient({
     : null;
   const hasList = listsForPlan && listsForPlan.length > 0;
   const firstListId = listsForPlan?.[0]?._id;
+  const hasRecentPlanHistory = (recentPlanHistory?.length ?? 0) > 0;
+  const shouldShowPlanOptionsMenu = currentPlan.isOwner || hasRecentPlanHistory;
 
   const isFinalised = currentPlan.isFinalised === true;
   const canShowAddAnotherMeal =
-    currentPlan.isOwner &&
-    !isFinalised &&
-    mealCount < MAX_DAYS_IN_MEAL_PLAN;
+    currentPlan.isOwner && !isFinalised && mealCount < MAX_DAYS_IN_MEAL_PLAN;
   const currentPlanStartDate = currentPlan.startDate ?? currentPlan.endDate;
   const currentPlanDayCount = Math.max(
     1,
@@ -2171,6 +2184,18 @@ export default function MealPlanClient({
                 </Select>
               </div>
             ) : null}
+            <div className="mt-2 flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 text-xs"
+                onClick={() => setShowRecentPlansDialog(true)}
+              >
+                <Clock3 className="size-3.5" />
+                Previous plans
+              </Button>
+            </div>
           </div>
           <div className="flex flex-wrap gap-2 items-center min-w-0 shrink-0">
             <Button variant="outline" asChild>
@@ -2223,32 +2248,43 @@ export default function MealPlanClient({
                     </span>
                   </Button>
                 )}
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="Plan options"
-                    >
-                      <MoreVertical className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => setShowEditDatesDialog(true)}>
-                      <CalendarPlus className="size-4 mr-2" />
-                      Edit plan dates
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => setShowDeletePlanDialog(true)}
-                    >
-                      <Trash2 className="size-4 mr-2" />
-                      Delete meal plan
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
               </>
             )}
+            {shouldShowPlanOptionsMenu ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon" aria-label="Plan options">
+                    <MoreVertical className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    disabled={!hasRecentPlanHistory}
+                    onClick={() => setShowRecentPlansDialog(true)}
+                  >
+                    <Clock3 className="size-4 mr-2" />
+                    Recent plans
+                  </DropdownMenuItem>
+                  {currentPlan.isOwner ? (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => setShowEditDatesDialog(true)}
+                      >
+                        <CalendarPlus className="size-4 mr-2" />
+                        Edit plan dates
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onClick={() => setShowDeletePlanDialog(true)}
+                      >
+                        <Trash2 className="size-4 mr-2" />
+                        Delete meal plan
+                      </DropdownMenuItem>
+                    </>
+                  ) : null}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
           </div>
         </div>
 
@@ -2330,6 +2366,58 @@ export default function MealPlanClient({
           </AlertDialogContent>
         </AlertDialog>
 
+        <Dialog
+          open={showRecentPlansDialog}
+          onOpenChange={setShowRecentPlansDialog}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Recent meal plans</DialogTitle>
+              <DialogDescription>
+                Open any plan from the last 4 weeks.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              {hasRecentPlanHistory ? (
+                (recentPlanHistory ?? []).map(
+                  (summary: MealPlanHistorySummary) => (
+                    <Button
+                      key={summary._id}
+                      type="button"
+                      variant="outline"
+                      className="w-full justify-between"
+                      onClick={() => {
+                        if (typeof window !== "undefined") {
+                          sessionStorage.setItem(
+                            MEAL_PLAN_LAST_VIEWED_STORAGE_KEY,
+                            summary._id,
+                          );
+                        }
+                        setShowRecentPlansDialog(false);
+                        router.push(ROUTES.mealPlanWithId(summary._id));
+                      }}
+                    >
+                      <span className="truncate">
+                        {formatPlanRangeShort(
+                          summary.startDate,
+                          summary.endDate,
+                        )}
+                      </span>
+                      <span className="ml-3 text-xs text-muted-foreground">
+                        {summary.isFinalised ? "Saved" : "Draft"}
+                      </span>
+                    </Button>
+                  ),
+                )
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No recent plans yet.
+                </p>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+
         <AlertDialog
           open={showFinaliseDialog}
           onOpenChange={setShowFinaliseDialog}
@@ -2358,13 +2446,16 @@ export default function MealPlanClient({
           </AlertDialogContent>
         </AlertDialog>
 
-        <Dialog open={showEditDatesDialog} onOpenChange={setShowEditDatesDialog}>
+        <Dialog
+          open={showEditDatesDialog}
+          onOpenChange={setShowEditDatesDialog}
+        >
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Edit plan dates</DialogTitle>
               <DialogDescription>
-                Choose a new start date and plan length. The end date is inferred
-                automatically.
+                Choose a new start date and plan length. The end date is
+                inferred automatically.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-4 py-2">
@@ -2398,7 +2489,8 @@ export default function MealPlanClient({
               <p className="text-sm text-muted-foreground">
                 {editPreviewEndDate !== null
                   ? `Range preview: ${formatPlanRangeShort(
-                      parseDateInputAsUtcStart(editStartDateInput) ?? currentPlanStartDate,
+                      parseDateInputAsUtcStart(editStartDateInput) ??
+                        currentPlanStartDate,
                       editPreviewEndDate,
                     )}`
                   : "Choose a valid date and length to preview the range."}
@@ -2417,7 +2509,9 @@ export default function MealPlanClient({
                 type="button"
                 onClick={() => void handleSavePlanDates()}
                 disabled={
-                  isUpdatingDateWindow || !isEditPlanDatesValid || !hasPlanDateEdits
+                  isUpdatingDateWindow ||
+                  !isEditPlanDatesValid ||
+                  !hasPlanDateEdits
                 }
               >
                 {isUpdatingDateWindow ? (


### PR DESCRIPTION
- Implemented a new query to fetch recent meal plans from the last four weeks, enhancing user access to historical meal data.
- Updated the MealPlanClient component to include a state for displaying recent plans and integrated a button for users to view this history.
- Enhanced the dropdown menu to conditionally show recent plans based on availability, improving user experience in meal plan management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Previous plans" feature allowing users to view and navigate to recently used meal plans
  * Introduced dedicated meal plan date editing dialog with validation

* **Bug Fixes**
  * Improved meal plan generation fallback handling to prevent stale notifications

* **Documentation**
  * Added backlog items documenting planned meal plan history retention and filtered list improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->