### PR TITLE
Return recent and previous meal plans in dashboard views

### DIFF
--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -43,7 +43,7 @@ import {
 import { getCurrentUser, getCurrentUserOrThrow } from "./users";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-const MEAL_PLAN_RETENTION_DAYS = 28;
+const MEAL_PLAN_RETENTION_DAYS = 30;
 const MEAL_PLAN_RETENTION_MS = MEAL_PLAN_RETENTION_DAYS * ONE_DAY_MS;
 
 function phraseDisplayLabel(normalised: string): string {
@@ -795,8 +795,15 @@ export const getActiveMealPlanSummaries = query({
 });
 
 /**
- * Recent historical meal plans (ended before viewer's local day, within 4 weeks)
- * for optional history UI. Excludes superseded plans.
+ * Recent historical meal plans (ended before viewer's local day) for history UI.
+ *
+ * Returns:
+ * - `recentPlans`: all plans (including replaced/regenerated ones) whose endDate
+ *   falls within the last MEAL_PLAN_RETENTION_DAYS days. Replaced plans are
+ *   intentionally included so users can navigate back to any past plan.
+ * - `previousPlan`: the single most recent plan whose endDate is older than the
+ *   retention window — always returned regardless of age so users can always reach
+ *   their last plan even after a long gap.
  */
 export const getRecentMealPlanHistory = query({
   args: {
@@ -804,12 +811,13 @@ export const getRecentMealPlanHistory = query({
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx);
-    if (!user) return [];
+    if (!user) return { recentPlans: [], previousPlan: null };
 
     const refLocalStart = resolveLocalDayRefMs(args.localDayStartMs);
     const cutoffStart = startOfDayMs(refLocalStart - MEAL_PLAN_RETENTION_MS);
 
-    const ownedPlans = await ctx.db
+    // --- Recent plans (within the retention window) ---
+    const ownedRecent = await ctx.db
       .query("mealPlans")
       .withIndex("by_user_and_endDate", (q) =>
         q
@@ -826,7 +834,7 @@ export const getRecentMealPlanHistory = query({
       .collect();
     const householdIds = memberships.map((m) => m.householdId);
 
-    const sharedPlanGroups = await Promise.all(
+    const sharedRecentGroups = await Promise.all(
       householdIds.map((householdId) =>
         ctx.db
           .query("mealPlans")
@@ -842,26 +850,75 @@ export const getRecentMealPlanHistory = query({
     );
 
     const seenIds = new Set<Id<"mealPlans">>();
-    const recentPlans = [...ownedPlans, ...sharedPlanGroups.flat()]
+    const recentPlans = [...ownedRecent, ...sharedRecentGroups.flat()]
       .filter((plan) => {
-        if (plan.replacedByPlanId !== undefined) return false;
         if (seenIds.has(plan._id)) return false;
         seenIds.add(plan._id);
         return true;
       })
       .sort(
-        (a, b) => b.endDate - a.endDate || (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
-      );
+        (a, b) =>
+          b.endDate - a.endDate || (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+      )
+      .map((plan) => ({
+        _id: plan._id,
+        startDate: plan.startDate,
+        endDate: plan.endDate,
+        isFinalised: plan.isFinalised === true,
+        updatedAt: plan.updatedAt,
+        isOwner: plan.userId === user._id,
+        householdId: plan.householdId,
+      }));
 
-    return recentPlans.map((plan) => ({
-      _id: plan._id,
-      startDate: plan.startDate,
-      endDate: plan.endDate,
-      isFinalised: plan.isFinalised === true,
-      updatedAt: plan.updatedAt,
-      isOwner: plan.userId === user._id,
-      householdId: plan.householdId,
-    }));
+    // --- Previous plan (most recent plan older than the retention window) ---
+    // Always returned so users can navigate to their last plan no matter how old.
+    const ownedPrevious = await ctx.db
+      .query("mealPlans")
+      .withIndex("by_user_and_endDate", (q) =>
+        q.eq("userId", user._id).lt("endDate", cutoffStart),
+      )
+      .order("desc")
+      .first();
+
+    const sharedPreviousGroups = await Promise.all(
+      householdIds.map((householdId) =>
+        ctx.db
+          .query("mealPlans")
+          .withIndex("by_household_and_endDate", (q) =>
+            q.eq("householdId", householdId).lt("endDate", cutoffStart),
+          )
+          .order("desc")
+          .first(),
+      ),
+    );
+
+    // Pick the most recent among owned + shared candidates
+    const previousCandidates = [
+      ownedPrevious,
+      ...sharedPreviousGroups,
+    ].filter((p): p is NonNullable<typeof p> => p !== null);
+    previousCandidates.sort(
+      (a, b) =>
+        b.endDate - a.endDate || (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+    );
+    const previousPlanDoc = previousCandidates[0] ?? null;
+
+    // Exclude if it was already captured in the recent window (edge case where
+    // cutoffStart rounding could overlap) or is the same as a recent plan.
+    const previousPlan =
+      previousPlanDoc && !seenIds.has(previousPlanDoc._id)
+        ? {
+            _id: previousPlanDoc._id,
+            startDate: previousPlanDoc.startDate,
+            endDate: previousPlanDoc.endDate,
+            isFinalised: previousPlanDoc.isFinalised === true,
+            updatedAt: previousPlanDoc.updatedAt,
+            isOwner: previousPlanDoc.userId === user._id,
+            householdId: previousPlanDoc.householdId,
+          }
+        : null;
+
+    return { recentPlans, previousPlan };
   },
 });
 

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -2446,7 +2446,7 @@ export default function MealPlanClient({
             <DialogHeader>
               <DialogTitle>Previous meal plans</DialogTitle>
               <DialogDescription>
-                Your recent plans and last saved plan.
+                Your recent plans and last earlier plan.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-2">

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import {
   Select,
   SelectContent,
@@ -233,7 +234,7 @@ type MealPlanSummary = NonNullable<
 >[number];
 type MealPlanHistorySummary = NonNullable<
   FunctionReturnType<typeof api.mealPlans.getRecentMealPlanHistory>
->[number];
+>["recentPlans"][number];
 
 type QuickMealsPresetId = "automatic" | "light" | "balanced" | "fast_focused";
 
@@ -271,6 +272,31 @@ const QUICK_MEAL_PRESETS: Array<{
     maxMinutes: 35,
   },
 ];
+
+/** Reusable button for a single plan in the history dialog or generation page. */
+function PlanHistoryButton({
+  summary,
+  onClick,
+}: {
+  summary: MealPlanHistorySummary;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className="w-full justify-between"
+      onClick={onClick}
+    >
+      <span className="truncate">
+        {formatPlanRangeShort(summary.startDate, summary.endDate)}
+      </span>
+      <span className="ml-3 text-xs text-muted-foreground">
+        {summary.isFinalised ? "Saved" : "Draft"}
+      </span>
+    </Button>
+  );
+}
 
 /** Shared header row for premium meal-plan generator sections (icon + title + Pro badge). */
 function MealPlanProSectionHeader({
@@ -1575,7 +1601,9 @@ export default function MealPlanClient({
               </p>
             </div>
           </div>
-          {planSummaries.length > 0 ? (
+          {(planSummaries.length > 0 ||
+            (recentPlanHistory?.recentPlans.length ?? 0) > 0 ||
+            recentPlanHistory?.previousPlan) ? (
             <Card className="mb-6 max-w-2xl mx-auto">
               <CardContent className="p-5 space-y-3">
                 <h2 className="font-semibold text-lg">Your Meal Plans</h2>
@@ -1600,6 +1628,44 @@ export default function MealPlanClient({
                       </span>
                     </Button>
                   ))}
+                  {(recentPlanHistory?.recentPlans.length ?? 0) > 0 && planSummaries.length > 0 && (
+                    <Separator className="my-1" />
+                  )}
+                  {(recentPlanHistory?.recentPlans ?? []).map(
+                    (summary: MealPlanHistorySummary) => (
+                      <PlanHistoryButton
+                        key={summary._id}
+                        summary={summary}
+                        onClick={() =>
+                          router.push(ROUTES.mealPlanWithId(summary._id))
+                        }
+                      />
+                    ),
+                  )}
+                  {recentPlanHistory?.previousPlan && (
+                    <>
+                      {((recentPlanHistory.recentPlans.length ?? 0) > 0 ||
+                        planSummaries.length > 0) && (
+                        <div className="flex items-center gap-2 pt-1">
+                          <Separator className="flex-1" />
+                          <span className="text-xs text-muted-foreground">
+                            Earlier
+                          </span>
+                          <Separator className="flex-1" />
+                        </div>
+                      )}
+                      <PlanHistoryButton
+                        summary={recentPlanHistory.previousPlan}
+                        onClick={() =>
+                          router.push(
+                            ROUTES.mealPlanWithId(
+                              recentPlanHistory.previousPlan!._id,
+                            ),
+                          )
+                        }
+                      />
+                    </>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -2087,7 +2153,9 @@ export default function MealPlanClient({
     : null;
   const hasList = listsForPlan && listsForPlan.length > 0;
   const firstListId = listsForPlan?.[0]?._id;
-  const hasRecentPlanHistory = (recentPlanHistory?.length ?? 0) > 0;
+  const hasRecentPlanHistory =
+    (recentPlanHistory?.recentPlans.length ?? 0) > 0 ||
+    recentPlanHistory?.previousPlan != null;
   const shouldShowPlanOptionsMenu = currentPlan.isOwner || hasRecentPlanHistory;
 
   const isFinalised = currentPlan.isFinalised === true;
@@ -2376,46 +2444,66 @@ export default function MealPlanClient({
         >
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Recent meal plans</DialogTitle>
+              <DialogTitle>Previous meal plans</DialogTitle>
               <DialogDescription>
-                Open any plan from the last 4 weeks.
+                Your recent plans and last saved plan.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-2">
               {hasRecentPlanHistory ? (
-                (recentPlanHistory ?? []).map(
-                  (summary: MealPlanHistorySummary) => (
-                    <Button
-                      key={summary._id}
-                      type="button"
-                      variant="outline"
-                      className="w-full justify-between"
-                      onClick={() => {
-                        if (typeof window !== "undefined") {
-                          sessionStorage.setItem(
-                            MEAL_PLAN_LAST_VIEWED_STORAGE_KEY,
-                            summary._id,
+                <>
+                  {(recentPlanHistory?.recentPlans ?? []).map(
+                    (summary: MealPlanHistorySummary) => (
+                      <PlanHistoryButton
+                        key={summary._id}
+                        summary={summary}
+                        onClick={() => {
+                          if (typeof window !== "undefined") {
+                            sessionStorage.setItem(
+                              MEAL_PLAN_LAST_VIEWED_STORAGE_KEY,
+                              summary._id,
+                            );
+                          }
+                          setShowRecentPlansDialog(false);
+                          router.push(ROUTES.mealPlanWithId(summary._id));
+                        }}
+                      />
+                    ),
+                  )}
+                  {recentPlanHistory?.previousPlan && (
+                    <>
+                      {(recentPlanHistory.recentPlans.length ?? 0) > 0 && (
+                        <div className="flex items-center gap-2 pt-1">
+                          <Separator className="flex-1" />
+                          <span className="text-xs text-muted-foreground">
+                            Earlier
+                          </span>
+                          <Separator className="flex-1" />
+                        </div>
+                      )}
+                      <PlanHistoryButton
+                        summary={recentPlanHistory.previousPlan}
+                        onClick={() => {
+                          if (typeof window !== "undefined") {
+                            sessionStorage.setItem(
+                              MEAL_PLAN_LAST_VIEWED_STORAGE_KEY,
+                              recentPlanHistory.previousPlan!._id,
+                            );
+                          }
+                          setShowRecentPlansDialog(false);
+                          router.push(
+                            ROUTES.mealPlanWithId(
+                              recentPlanHistory.previousPlan!._id,
+                            ),
                           );
-                        }
-                        setShowRecentPlansDialog(false);
-                        router.push(ROUTES.mealPlanWithId(summary._id));
-                      }}
-                    >
-                      <span className="truncate">
-                        {formatPlanRangeShort(
-                          summary.startDate,
-                          summary.endDate,
-                        )}
-                      </span>
-                      <span className="ml-3 text-xs text-muted-foreground">
-                        {summary.isFinalised ? "Saved" : "Draft"}
-                      </span>
-                    </Button>
-                  ),
-                )
+                        }}
+                      />
+                    </>
+                  )}
+                </>
               ) : (
                 <p className="text-sm text-muted-foreground">
-                  No recent plans yet.
+                  No previous plans yet.
                 </p>
               )}
             </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meal plan history now shows recent plans plus a single older “previous” plan for easier browsing of past meals.
  * Added a reusable history entry component that displays the date range and plan status (for example, “Saved” or “Draft”).

* **Bug Fixes**
  * Improved how owned and shared meal plans are combined, deduplicated, and ordered for the history view.
  * Updated the “Previous meal plans” dialog and navigation so selecting an entry opens the correct plan.
  * Extended the lookback window for what counts as “recent” meal plan history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->