### PR TITLE
feat: add paginated meal plan summaries and previous plans nudge

### DIFF
--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -939,13 +939,18 @@ export const getMealPlanSummariesPaged = query({
     if (!user) return { plans: [], hasMore: false };
 
     const limit = Math.max(1, Math.min(args.limit, 50));
-    const fetch = limit + 1;
+    // The by_*_and_endDate indexes order by endDate only. The merge sort uses
+    // updatedAt as a tie-breaker, so plans with the same endDate can appear in
+    // a different order per source than the final merged order. Fetching a
+    // larger buffer per source (4× + 1, capped at 100) ensures that even in
+    // pathological tie scenarios all relevant candidates reach the merge step.
+    const perSourceFetch = Math.min((limit + 1) * 4, 100);
 
     const ownedPlans = await ctx.db
       .query("mealPlans")
       .withIndex("by_user_and_endDate", (q) => q.eq("userId", user._id))
       .order("desc")
-      .take(fetch);
+      .take(perSourceFetch);
 
     const memberships = await ctx.db
       .query("householdMembers")
@@ -961,7 +966,7 @@ export const getMealPlanSummariesPaged = query({
             q.eq("householdId", householdId),
           )
           .order("desc")
-          .take(fetch),
+          .take(perSourceFetch),
       ),
     );
 

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -923,6 +923,76 @@ export const getRecentMealPlanHistory = query({
 });
 
 /**
+ * Paginated meal plan history (active + past) ordered by endDate desc.
+ * Used by the "Previous plans" dialog and dashboard nudge.
+ *
+ * Returns:
+ * - `plans`: up to `limit` plans across owned + household, sorted by endDate desc
+ * - `hasMore`: true if there are additional plans beyond the returned page
+ */
+export const getMealPlanSummariesPaged = query({
+  args: {
+    limit: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) return { plans: [], hasMore: false };
+
+    const limit = Math.max(1, Math.min(args.limit, 50));
+    const fetch = limit + 1;
+
+    const ownedPlans = await ctx.db
+      .query("mealPlans")
+      .withIndex("by_user_and_endDate", (q) => q.eq("userId", user._id))
+      .order("desc")
+      .take(fetch);
+
+    const memberships = await ctx.db
+      .query("householdMembers")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+    const householdIds = memberships.map((m) => m.householdId);
+
+    const householdPlanGroups = await Promise.all(
+      householdIds.map((householdId) =>
+        ctx.db
+          .query("mealPlans")
+          .withIndex("by_household_and_endDate", (q) =>
+            q.eq("householdId", householdId),
+          )
+          .order("desc")
+          .take(fetch),
+      ),
+    );
+
+    const seenIds = new Set<Id<"mealPlans">>();
+    const merged = [...ownedPlans, ...householdPlanGroups.flat()]
+      .filter((plan) => {
+        if (seenIds.has(plan._id)) return false;
+        seenIds.add(plan._id);
+        return true;
+      })
+      .sort(
+        (a, b) =>
+          b.endDate - a.endDate || (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+      );
+
+    const hasMore = merged.length > limit;
+    const plans = merged.slice(0, limit).map((plan) => ({
+      _id: plan._id,
+      startDate: plan.startDate,
+      endDate: plan.endDate,
+      isFinalised: plan.isFinalised === true,
+      updatedAt: plan.updatedAt,
+      isOwner: plan.userId === user._id,
+      householdId: plan.householdId,
+    }));
+
+    return { plans, hasMore };
+  },
+});
+
+/**
  * Count owned plans that would block free-tier additional plan creation:
  * unreplaced plans with endDate >= today (UTC day start).
  */

--- a/convex/mealPlans.ts
+++ b/convex/mealPlans.ts
@@ -938,7 +938,8 @@ export const getMealPlanSummariesPaged = query({
     const user = await getCurrentUser(ctx);
     if (!user) return { plans: [], hasMore: false };
 
-    const limit = Math.max(1, Math.min(args.limit, 50));
+    const MAX_LIMIT = 50;
+    const limit = Math.max(1, Math.min(args.limit, MAX_LIMIT));
     // The by_*_and_endDate indexes order by endDate only. The merge sort uses
     // updatedAt as a tie-breaker, so plans with the same endDate can appear in
     // a different order per source than the final merged order. Fetching a
@@ -982,7 +983,12 @@ export const getMealPlanSummariesPaged = query({
           b.endDate - a.endDate || (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
       );
 
-    const hasMore = merged.length > limit;
+    // When limit has been clamped to MAX_LIMIT, the client cannot receive more
+    // plans by incrementing further — returning hasMore=true would cause an
+    // infinite "Load more" loop with no new data. Force false at the cap so the
+    // client knows it has reached the maximum supported page size.
+    const atCap = limit === MAX_LIMIT;
+    const hasMore = !atCap && merged.length > limit;
     const plans = merged.slice(0, limit).map((plan) => ({
       _id: plan._id,
       startDate: plan.startDate,

--- a/src/app/(app)/dashboard/_components/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/_components/dashboard-client.tsx
@@ -37,7 +37,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { useCurrentMealPlan } from "@/app/(app)/_components.tsx/current-meal-plan-context";
-import { MealPlanOverviewSection } from "./meal-plan-overview-section";
+import { MealPlanOverviewSection, PreviousMealPlanNudge } from "./meal-plan-overview-section";
 import { TodaysMealSpotlight } from "./todays-meal-spotlight";
 
 type RecentActivity = FunctionReturnType<typeof api.recipes.getRecentActivity>;
@@ -516,6 +516,7 @@ export default function DashboardClient() {
       <HeroSection />
       <TodaysMealSpotlight />
       <MealPlanOverviewSection />
+      <PreviousMealPlanNudge />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
         {/* Activity Feed */}

--- a/src/app/(app)/dashboard/_components/meal-plan-overview-section.tsx
+++ b/src/app/(app)/dashboard/_components/meal-plan-overview-section.tsx
@@ -6,11 +6,13 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn, startOfDayMs } from "@/lib/utils";
+import { api } from "convex/_generated/api";
 import type { Id } from "convex/_generated/dataModel";
-import { CalendarCheck, ChefHat, Clock } from "lucide-react";
+import { CalendarCheck, CalendarDays, ChefHat, Clock } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useMemo } from "react";
+import { useQuery } from "convex/react";
 
 function formatDateShortUtc(ms: number): string {
   return new Date(ms).toLocaleDateString(undefined, {
@@ -269,6 +271,56 @@ export function MealPlanOverviewSection() {
               </div>
             </div>
           )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Shown on the dashboard when the user has no active plan but has at least one
+ * past plan. Surfaces the most recent plan as a lightweight nudge so users can
+ * quickly jump back in.
+ */
+export function PreviousMealPlanNudge() {
+  const { currentPlan } = useCurrentMealPlan();
+  const result = useQuery(
+    api.mealPlans.getMealPlanSummariesPaged,
+    currentPlan === null ? { limit: 1 } : "skip",
+  );
+
+  if (currentPlan !== null) return null;
+  if (!result || result.plans.length === 0) return null;
+
+  const plan = result.plans[0];
+  const planHref = ROUTES.mealPlanWithId(plan._id);
+  const displayStart = plan.startDate;
+  const displayEnd = plan.endDate;
+
+  return (
+    <Card className="mb-6 border-border/50 bg-muted/20">
+      <CardContent className="p-4 sm:p-5">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+          <div className="flex items-center gap-3 min-w-0 flex-1">
+            <div className="p-2 rounded-lg bg-muted shrink-0">
+              <CalendarDays className="size-5 text-muted-foreground" aria-hidden />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide mb-0.5">
+                Your last meal plan
+              </p>
+              <p className="text-sm font-semibold text-foreground truncate">
+                {formatDateShortUtc(displayStart ?? displayEnd)} –{" "}
+                {formatDateShortUtc(displayEnd)}
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  {plan.isFinalised ? "Saved" : "Draft"}
+                </span>
+              </p>
+            </div>
+          </div>
+          <Button asChild variant="outline" size="sm" className="shrink-0 self-start sm:self-auto">
+            <Link href={planHref}>View plan</Link>
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -274,27 +274,43 @@ const QUICK_MEAL_PRESETS: Array<{
   },
 ];
 
-/** Reusable button for a single plan in the history dialog or generation page. */
-function PlanHistoryButton({
-  summary,
+/** Minimal shape required to render a plan row — compatible with both history query types. */
+type PlanRowData = {
+  _id: Id<"mealPlans">;
+  startDate?: number;
+  endDate: number;
+  isFinalised: boolean;
+};
+
+/** Unified plan-row button used in every meal-plan history list. */
+function PlanRow({
+  plan,
   onClick,
 }: {
-  summary: MealPlanHistorySummary;
+  plan: PlanRowData;
   onClick: () => void;
 }) {
   return (
     <Button
       type="button"
-      variant="outline"
-      className="w-full justify-between"
+      variant="ghost"
+      className="h-auto w-full justify-between px-3 py-2.5"
       onClick={onClick}
     >
-      <span className="truncate">
-        {formatPlanRangeShort(summary.startDate, summary.endDate)}
+      <span className="truncate font-medium">
+        {formatPlanRangeShort(plan.startDate, plan.endDate)}
       </span>
-      <span className="ml-3 text-xs text-muted-foreground">
-        {summary.isFinalised ? "Saved" : "Draft"}
-      </span>
+      <Badge
+        variant="secondary"
+        className={cn(
+          "ml-3 shrink-0 text-xs",
+          plan.isFinalised
+            ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+            : "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+        )}
+      >
+        {plan.isFinalised ? "Saved" : "Draft"}
+      </Badge>
     </Button>
   );
 }
@@ -310,13 +326,31 @@ function PlanHistoryDialog({
   onNavigate: (planId: Id<"mealPlans">) => void;
 }) {
   const [limit, setLimit] = useState(4);
-  const result = useQuery(api.mealPlans.getMealPlanSummariesPaged, { limit });
-  const plans = result?.plans ?? [];
+
+  // Gate query to open state — avoids a live subscription while dialog is closed.
+  const result = useQuery(
+    api.mealPlans.getMealPlanSummariesPaged,
+    open ? { limit } : "skip",
+  );
+
+  // Preserve the last known plans so "Load more" doesn't blank the list while
+  // the next page is in-flight (result goes undefined during a limit change).
+  const prevPlansRef = useRef<NonNullable<typeof result>["plans"]>([]);
+  if (result?.plans !== undefined) {
+    prevPlansRef.current = result.plans;
+  }
+  const displayedPlans = result?.plans ?? prevPlansRef.current;
   const hasMore = result?.hasMore ?? false;
-  const isLoading = result === undefined;
+  const isInitialLoading = result === undefined && displayedPlans.length === 0;
+  const isLoadingMore = result === undefined && displayedPlans.length > 0;
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) setLimit(4);
+    onOpenChange(isOpen);
+  };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Your meal plans</DialogTitle>
@@ -325,47 +359,35 @@ function PlanHistoryDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="max-h-[60vh] overflow-y-auto space-y-1 pr-0.5">
-          {isLoading ? (
+          {isInitialLoading ? (
             <div className="space-y-2">
               {Array.from({ length: 4 }).map((_, i) => (
                 <Skeleton key={i} className="h-10 w-full rounded-md" />
               ))}
             </div>
-          ) : plans.length === 0 ? (
+          ) : displayedPlans.length === 0 ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
               No meal plans yet.
             </p>
           ) : (
-            plans.map((plan) => (
-              <Button
+            displayedPlans.map((plan) => (
+              <PlanRow
                 key={plan._id}
-                type="button"
-                variant="ghost"
-                className="h-auto w-full justify-between px-3 py-2.5"
+                plan={plan}
                 onClick={() => {
                   onNavigate(plan._id);
-                  onOpenChange(false);
+                  handleOpenChange(false);
                 }}
-              >
-                <span className="font-medium">
-                  {formatPlanRangeShort(plan.startDate, plan.endDate)}
-                </span>
-                <Badge
-                  variant="secondary"
-                  className={cn(
-                    "ml-3 text-xs",
-                    plan.isFinalised
-                      ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-                      : "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
-                  )}
-                >
-                  {plan.isFinalised ? "Saved" : "Draft"}
-                </Badge>
-              </Button>
+              />
             ))
           )}
+          {isLoadingMore && (
+            <div className="flex items-center justify-center py-2">
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </div>
+          )}
         </div>
-        {hasMore && (
+        {hasMore && !isLoadingMore && (
           <DialogFooter className="sm:justify-start pt-1">
             <Button
               type="button"
@@ -2492,9 +2514,9 @@ export default function MealPlanClient({
                 <>
                   {(recentPlanHistory?.recentPlans ?? []).map(
                     (summary: MealPlanHistorySummary) => (
-                      <PlanHistoryButton
+                      <PlanRow
                         key={summary._id}
-                        summary={summary}
+                        plan={summary}
                         onClick={() => {
                           if (typeof window !== "undefined") {
                             sessionStorage.setItem(
@@ -2519,8 +2541,8 @@ export default function MealPlanClient({
                           <Separator className="flex-1" />
                         </div>
                       )}
-                      <PlanHistoryButton
-                        summary={recentPlanHistory.previousPlan}
+                      <PlanRow
+                        plan={recentPlanHistory.previousPlan}
                         onClick={() => {
                           if (typeof window !== "undefined") {
                             sessionStorage.setItem(

--- a/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
+++ b/src/app/(app)/dashboard/meal-plan/_components/meal-plan-client.tsx
@@ -65,6 +65,7 @@ import {
   Check,
   CheckCircle2,
   Clock3,
+  History,
   Home,
   Loader2,
   MoreVertical,
@@ -295,6 +296,89 @@ function PlanHistoryButton({
         {summary.isFinalised ? "Saved" : "Draft"}
       </span>
     </Button>
+  );
+}
+
+/** Paginated "Previous plans" dialog used on the generation page. */
+function PlanHistoryDialog({
+  open,
+  onOpenChange,
+  onNavigate,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate: (planId: Id<"mealPlans">) => void;
+}) {
+  const [limit, setLimit] = useState(4);
+  const result = useQuery(api.mealPlans.getMealPlanSummariesPaged, { limit });
+  const plans = result?.plans ?? [];
+  const hasMore = result?.hasMore ?? false;
+  const isLoading = result === undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Your meal plans</DialogTitle>
+          <DialogDescription>
+            Browse and open any of your plans.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto space-y-1 pr-0.5">
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full rounded-md" />
+              ))}
+            </div>
+          ) : plans.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No meal plans yet.
+            </p>
+          ) : (
+            plans.map((plan) => (
+              <Button
+                key={plan._id}
+                type="button"
+                variant="ghost"
+                className="h-auto w-full justify-between px-3 py-2.5"
+                onClick={() => {
+                  onNavigate(plan._id);
+                  onOpenChange(false);
+                }}
+              >
+                <span className="font-medium">
+                  {formatPlanRangeShort(plan.startDate, plan.endDate)}
+                </span>
+                <Badge
+                  variant="secondary"
+                  className={cn(
+                    "ml-3 text-xs",
+                    plan.isFinalised
+                      ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                      : "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+                  )}
+                >
+                  {plan.isFinalised ? "Saved" : "Draft"}
+                </Badge>
+              </Button>
+            ))
+          )}
+        </div>
+        {hasMore && (
+          <DialogFooter className="sm:justify-start pt-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setLimit((l) => l + 4)}
+            >
+              Load more
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -768,6 +852,7 @@ export default function MealPlanClient({
   const [showUnshareConfirmDialog, setShowUnshareConfirmDialog] =
     useState(false);
   const [showRecentPlansDialog, setShowRecentPlansDialog] = useState(false);
+  const [showPlanHistoryDialog, setShowPlanHistoryDialog] = useState(false);
   const [showFinaliseDialog, setShowFinaliseDialog] = useState(false);
   const [showEditDatesDialog, setShowEditDatesDialog] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -1588,6 +1673,11 @@ export default function MealPlanClient({
   }
 
   if (generationOnly) {
+    const hasAnyPlans =
+      planSummaries.length > 0 ||
+      (recentPlanHistory?.recentPlans.length ?? 0) > 0 ||
+      recentPlanHistory?.previousPlan != null;
+
     return (
       <div className="bg-background w-full min-w-0 overflow-x-hidden">
         <div className="container mx-auto px-4 py-8">
@@ -1600,76 +1690,24 @@ export default function MealPlanClient({
                 Pick your timing, then generate a dedicated meal plan page.
               </p>
             </div>
+            {hasAnyPlans && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 self-start gap-1.5"
+                onClick={() => setShowPlanHistoryDialog(true)}
+              >
+                <History className="size-3.5" aria-hidden />
+                Previous plans
+              </Button>
+            )}
           </div>
-          {(planSummaries.length > 0 ||
-            (recentPlanHistory?.recentPlans.length ?? 0) > 0 ||
-            recentPlanHistory?.previousPlan) ? (
-            <Card className="mb-6 max-w-2xl mx-auto">
-              <CardContent className="p-5 space-y-3">
-                <h2 className="font-semibold text-lg">Your Meal Plans</h2>
-                <div className="space-y-2">
-                  {planSummaries.map((summary) => (
-                    <Button
-                      key={summary._id}
-                      variant="outline"
-                      className="w-full justify-between"
-                      onClick={() =>
-                        router.push(ROUTES.mealPlanWithId(summary._id))
-                      }
-                    >
-                      <span>
-                        {formatPlanRangeShort(
-                          summary.startDate,
-                          summary.endDate,
-                        )}
-                      </span>
-                      <span className="text-muted-foreground">
-                        {summary.isFinalised ? "Saved" : "Draft"}
-                      </span>
-                    </Button>
-                  ))}
-                  {(recentPlanHistory?.recentPlans.length ?? 0) > 0 && planSummaries.length > 0 && (
-                    <Separator className="my-1" />
-                  )}
-                  {(recentPlanHistory?.recentPlans ?? []).map(
-                    (summary: MealPlanHistorySummary) => (
-                      <PlanHistoryButton
-                        key={summary._id}
-                        summary={summary}
-                        onClick={() =>
-                          router.push(ROUTES.mealPlanWithId(summary._id))
-                        }
-                      />
-                    ),
-                  )}
-                  {recentPlanHistory?.previousPlan && (
-                    <>
-                      {((recentPlanHistory.recentPlans.length ?? 0) > 0 ||
-                        planSummaries.length > 0) && (
-                        <div className="flex items-center gap-2 pt-1">
-                          <Separator className="flex-1" />
-                          <span className="text-xs text-muted-foreground">
-                            Earlier
-                          </span>
-                          <Separator className="flex-1" />
-                        </div>
-                      )}
-                      <PlanHistoryButton
-                        summary={recentPlanHistory.previousPlan}
-                        onClick={() =>
-                          router.push(
-                            ROUTES.mealPlanWithId(
-                              recentPlanHistory.previousPlan!._id,
-                            ),
-                          )
-                        }
-                      />
-                    </>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          ) : null}
+          <PlanHistoryDialog
+            open={showPlanHistoryDialog}
+            onOpenChange={setShowPlanHistoryDialog}
+            onNavigate={(id) => router.push(ROUTES.mealPlanWithId(id))}
+          />
           <Card className="mb-6 border-border/80 bg-muted/20 max-w-2xl mx-auto">
             <CardContent className="p-3 space-y-3">
               <MealPlanProSectionHeader


### PR DESCRIPTION
- Introduced `getMealPlanSummariesPaged` query to retrieve paginated meal plans, including both owned and household plans, sorted by end date.
- Implemented `PreviousMealPlanNudge` component to display the most recent past meal plan when no active plan exists, encouraging user engagement.
- Enhanced `MealPlanClient` to include a button for accessing previous plans, improving navigation and user experience on the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a paginated meal plan history covering both personal plans and plans shared within the user’s household.
  * Added a dashboard nudge that surfaces the user’s last meal plan with a quick “View plan” link.
  * Added a “Previous plans” browsing experience on meal plan pages, with a dialog to open older plans.
* **Bug Fixes**
  * Improved meal plan history ordering and deduplication for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->